### PR TITLE
Refactor project window handling and navigation logic; remove unused …

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,5 @@
 /* eslint global-require: off, no-console: off, promise/always-return: off, no-restricted-syntax: off, no-await-in-loop: off */
-import { app, ipcMain, protocol } from 'electron';
+import { app, protocol } from 'electron';
 import { WindowManager } from './windows';
 import { loadEnvironment } from './utils/setupHelpers';
 import { AssetUrl } from './utils/assetUrl';
@@ -126,18 +126,6 @@ if (!gotTheLock) {
       activeWindow.focus();
     } else {
       windowManager.startApplication();
-    }
-  });
-
-  ipcMain.handle('windows:openSelector', () => {
-    if (windowManager) {
-      windowManager.showProjectWindow();
-    }
-  });
-
-  ipcMain.handle('windows:closeSelector', () => {
-    if (windowManager) {
-      windowManager.closeProjectWindow();
     }
   });
 }

--- a/src/main/windows/index.ts
+++ b/src/main/windows/index.ts
@@ -4,12 +4,9 @@ import { createMainWindow } from './main';
 import registerHandlers from '../ipcSetup';
 import { installExtensions } from '../utils/setupHelpers';
 import { ProjectsService } from '../services';
-import { createProjectWindow } from './project';
 
 export class WindowManager {
   private splashWindow: BrowserWindow | null = null;
-
-  private projectWindow: BrowserWindow | null = null;
 
   private mainWindow: BrowserWindow | null = null;
 
@@ -22,50 +19,6 @@ export class WindowManager {
 
   private showSplashScreen() {
     this.splashWindow = createSplashWindow();
-  }
-
-  public showProjectWindow() {
-    if (this.projectWindow) {
-      return new Promise<void>((resolve) => {
-        resolve();
-      });
-    }
-
-    this.projectWindow = createProjectWindow();
-    this.projectWindow.setParentWindow(this.mainWindow);
-    this.projectWindow.on('closed', () => {
-      this.projectWindow = null;
-      if (this.mainWindow) {
-        this.mainWindow.reload();
-        this.mainWindow.focus();
-      }
-    });
-
-    return new Promise<void>((resolve) => {
-      if (!this.projectWindow) {
-        resolve();
-        return;
-      }
-
-      this.projectWindow.once('ready-to-show', () => {
-        if (this.projectWindow) {
-          this.projectWindow.show();
-          this.projectWindow.focus();
-        }
-        resolve();
-      });
-    });
-  }
-
-  public closeProjectWindow() {
-    if (this.projectWindow) {
-      this.projectWindow.close();
-      this.projectWindow = null;
-      if (this.mainWindow) {
-        this.mainWindow.show();
-        this.mainWindow.focus();
-      }
-    }
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -109,7 +62,7 @@ export class WindowManager {
         'project:select',
         async (_event, body: { projectId: string }) => {
           await ProjectsService.selectProject(body);
-          this.mainWindow?.reload();
+          // Removed reload that breaks the render
         },
       );
     });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -23,61 +23,67 @@ import { SelectProjectLayout } from './layouts';
 import { AppProvider } from './context';
 import { QueryClientContextProvider } from './context/QueryClientContext';
 import { themeStorageManager, getStoredThemeMode } from './utils/themeStorage';
-import { ScrollbarStyles } from './components';
+import { ScrollbarStyles } from './components/scrollbarStyles';
+
+const App: React.FC = () => {
+  return (
+    <Router>
+      <CssBaseline />
+      <ScrollbarStyles />
+      <Routes>
+        <Route path="/" element={<SelectProjectLayout />}>
+          <Route path="/select-project" element={<SelectProject />} />
+          <Route path="*" element={<Navigate to="/" />} />
+        </Route>
+        <Route path="/app">
+          <Route path="" element={<ProjectDetails />} />
+          <Route path="select-project" element={<SelectProject />} />
+          <Route path="edit-connection" element={<EditConnection />} />
+          <Route path="add-connection" element={<AddConnection />} />
+          <Route
+            path="settings"
+            element={<Navigate to="/app/settings/general" />}
+          />
+          <Route path="settings/general" element={<Settings />} />
+          <Route path="settings/ai-providers" element={<Settings />} />
+          <Route path="settings/dbt" element={<Settings />} />
+          <Route path="settings/rosetta" element={<Settings />} />
+          <Route path="settings/about" element={<Settings />} />
+          <Route path="sql" element={<Sql />} />
+          <Route path="*" element={<Navigate to="/app" />} />
+        </Route>
+      </Routes>
+    </Router>
+  );
+};
 
 const AppWithProjectProvider: React.FC = () => {
+  // Get the initially stored theme mode
   const initialMode = getStoredThemeMode();
 
   return (
-    <Router>
-      <QueryClientContextProvider>
+    <QueryClientContextProvider>
+      <AppProvider>
         <CssVarsProvider
           theme={theme}
           defaultMode={initialMode}
           storageManager={themeStorageManager}
         >
-          <AppProvider>
-            <CssBaseline />
-            <ScrollbarStyles />
-            <Routes>
-              <Route path="/" element={<SelectProjectLayout />}>
-                <Route path="/select-project" element={<SelectProject />} />
-                <Route path="*" element={<Navigate to="/" />} />
-              </Route>
-              <Route path="/app">
-                <Route path="" element={<ProjectDetails />} />
-                <Route path="select-project" element={<SelectProject />} />
-                <Route path="edit-connection" element={<EditConnection />} />
-                <Route path="add-connection" element={<AddConnection />} />
-                <Route
-                  path="settings"
-                  element={<Navigate to="/app/settings/general" />}
-                />
-                <Route path="settings/general" element={<Settings />} />
-                <Route path="settings/ai-providers" element={<Settings />} />
-                <Route path="settings/dbt" element={<Settings />} />
-                <Route path="settings/rosetta" element={<Settings />} />
-                <Route path="settings/about" element={<Settings />} />
-                <Route path="sql" element={<Sql />} />
-                <Route path="*" element={<Navigate to="/app" />} />
-              </Route>
-            </Routes>
-
-            <ToastContainer
-              position="bottom-right"
-              autoClose={5000}
-              hideProgressBar={false}
-              newestOnTop={false}
-              closeOnClick={false}
-              rtl={false}
-              pauseOnFocusLoss
-              pauseOnHover
-              theme={initialMode === 'dark' ? 'dark' : 'light'}
-            />
-          </AppProvider>
+          <App />
+          <ToastContainer
+            position="bottom-right"
+            autoClose={5000}
+            hideProgressBar={false}
+            newestOnTop={false}
+            closeOnClick={false}
+            rtl={false}
+            pauseOnFocusLoss
+            pauseOnHover
+            theme={initialMode === 'dark' ? 'dark' : 'light'}
+          />
         </CssVarsProvider>
-      </QueryClientContextProvider>
-    </Router>
+      </AppProvider>
+    </QueryClientContextProvider>
   );
 };
 

--- a/src/renderer/components/menu/index.tsx
+++ b/src/renderer/components/menu/index.tsx
@@ -35,7 +35,6 @@ import { Icon } from '../icon';
 import { projectsServices } from '../../services';
 import { LetterAvatar } from '../letterAvatar';
 import { useAppContext } from '../../hooks';
-import { client } from '../../config/client';
 
 export const Menu: React.FC = () => {
   const navigate = useNavigate();
@@ -137,11 +136,12 @@ export const Menu: React.FC = () => {
             ]}
             onSelect={async (value) => {
               if (value === 'new') {
-                client.get('windows:openSelector');
-                return;
+                await projectsServices.selectProject({ projectId: '' });
+                navigate('/app/select-project');
+              } else {
+                await projectsServices.selectProject({ projectId: value });
+                navigate('/app');
               }
-              await projectsServices.selectProject({ projectId: value });
-              navigate('/app');
             }}
             selectedItem={String(project?.id)}
             anchorElement={

--- a/src/renderer/context/AppProvider.tsx
+++ b/src/renderer/context/AppProvider.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
-import { Box, Typography, Button } from '@mui/material';
 import { AppContextType } from '../../types/frontend';
 import { Splash } from '../components';
 import { useGetProjects, useGetSelectedProject } from '../controllers';
 import { Project, Table } from '../../types/backend';
 import { projectsServices } from '../services';
-import { client } from '../config/client';
-import { logo } from '../../../assets';
 
 type Props = {
   children: React.ReactNode;
@@ -28,7 +24,6 @@ const AppProvider: React.FC<Props> = ({ children }) => {
   const { data: projects = [] } = useGetProjects();
   const { data: selectedProject, isLoading } = useGetSelectedProject();
 
-  const location = useLocation();
   const [isSidebarOpen, setIsSidebarOpen] = React.useState(true);
   const [isLoadingSchema, setIsLoadingSchema] = React.useState(false);
   const [schema, setSchema] = React.useState<Table[]>();
@@ -72,56 +67,6 @@ const AppProvider: React.FC<Props> = ({ children }) => {
 
   if (isLoading) {
     return <Splash loaderMessage="Loading project..." />;
-  }
-
-  if (!selectedProject && !location.pathname.includes('select-project')) {
-    return (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: 'calc(100vh - 48px)',
-          textAlign: 'center',
-          padding: 3,
-          bgcolor: (theme) => theme.palette.background.default,
-        }}
-      >
-        <img
-          src={logo}
-          alt="RosettaDB Logo"
-          style={{ width: 180, marginBottom: 24 }}
-        />
-        <Typography variant="h5" gutterBottom color="text.primary">
-          No Project Selected
-        </Typography>
-        <Typography
-          variant="body1"
-          color="text.secondary"
-          sx={{ maxWidth: 500, mb: 4 }}
-        >
-          You need to select or create a project to get started with Rosetta dbt
-          Studio.
-        </Typography>
-        <Button
-          variant="contained"
-          size="medium"
-          sx={(theme) => ({
-            bgcolor: theme.palette.primary.main,
-            color: theme.palette.primary.contrastText,
-            '&:hover': {
-              bgcolor: theme.palette.primary.dark,
-            },
-            px: 3,
-            py: 1,
-          })}
-          onClick={() => client.get('windows:openSelector')}
-        >
-          Select or Create Project
-        </Button>
-      </Box>
-    );
   }
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/src/renderer/screens/projectDetails/index.tsx
+++ b/src/renderer/screens/projectDetails/index.tsx
@@ -32,7 +32,7 @@ import {
   SelectedFile,
 } from './styles';
 import { useRosettaDBT, useDbt } from '../../hooks';
-import { GenerateDashboardResponseType } from '../../../types/backend';
+import { GenerateDashboardResponseType, Project } from '../../../types/backend';
 import { AI_PROMPTS } from '../../config/constants';
 import { utils } from '../../helpers';
 import { AppLayout } from '../../layouts';
@@ -48,15 +48,30 @@ const ProjectDetails: React.FC = () => {
   const [isQueryOpen, setIsQueryOpen] = React.useState(false);
   const [isLoadingQuery, setIsLoadingQuery] = React.useState(false);
 
+  // Early return for loading state
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  // Early return for no project
+  if (!project) {
+    return <Navigate to="/app/select-project" />;
+  }
+
+  // Early return for missing connection
+  if (project?.id && !project?.rosettaConnection) {
+    return <Navigate to="/app/add-connection/" />;
+  }
+
   const {
     data: directories,
     isLoading: isLoadingDirectories,
     refetch: fetchDirectories,
-  } = useGetProjectFiles(project!);
+  } = useGetProjectFiles(project);
 
   const { fn: rosettaDbt, isRunning: isRunningRosettaDbt } = useRosettaDBT(
     async () => {
-      await projectsServices.postRosettaDBTCopy(project!);
+      await projectsServices.postRosettaDBTCopy(project);
       await fetchDirectories();
     },
   );
@@ -74,8 +89,8 @@ const ProjectDetails: React.FC = () => {
   });
 
   const { data: statuses = [], refetch: updateStatuses } = useGetFileStatuses(
-    project!.path,
-    { enabled: !!project!.path },
+    project.path,
+    { enabled: !!project.path },
   );
 
   const [selectedFilePath, setSelectedFilePath] = React.useState<string>();
@@ -260,18 +275,6 @@ const ProjectDetails: React.FC = () => {
     return settings?.dbtPath && settings.dbtPath.trim() !== '';
   }, [settings?.dbtPath]);
 
-  if (isLoading) {
-    return <Loader />;
-  }
-
-  if (!project) {
-    return <Navigate to="/app/select-project" />;
-  }
-
-  if (project?.id && !project?.rosettaConnection) {
-    return <Navigate to="/app/add-connection/" />;
-  }
-
   return (
     <AppLayout
       sidebarContent={
@@ -338,14 +341,7 @@ const ProjectDetails: React.FC = () => {
             <EditorContainer>
               <Header>
                 {selectedFilePath && (
-                  <SelectedFile
-                    onClick={async () => {
-                      await window.navigator.clipboard.writeText(
-                        selectedFilePath ?? '',
-                      );
-                      toast.info('File path is copied to clipboard');
-                    }}
-                  >
+                  <SelectedFile>
                     {utils.splitPath(selectedFilePath ?? '', project.name)}
                   </SelectedFile>
                 )}

--- a/src/renderer/screens/selectProject/index.tsx
+++ b/src/renderer/screens/selectProject/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Button,
   TextField,
@@ -36,7 +37,6 @@ import {
 } from '../../controllers';
 import { CloneRepoModal, Icon } from '../../components';
 import { icons, logo } from '../../../../assets';
-import { client } from '../../config/client';
 
 const ProjectSelectionContainer = styled(Box)`
   padding: 0.5rem 2rem 2rem;
@@ -188,6 +188,7 @@ const TaglineLogo = styled('img')`
 `;
 
 const SelectProject: React.FC = () => {
+  const navigate = useNavigate();
   const { data: settings } = useGetSettings();
   const { data: projects = [] } = useGetProjects();
   const [isCloneModalOpen, setIsCloneModalOpen] = React.useState(false);
@@ -302,10 +303,10 @@ const SelectProject: React.FC = () => {
         name: `${defaultProjectPath}/${newProject.name}`,
       });
       await projectsServices.selectProject({ projectId: project.id });
+      navigate('/app');
       toast.success(`Project ${project.name} created successfully!`);
       setIsAddingProject(false);
       setNewProject({ name: '' });
-      await client.get('windows:closeSelector');
     } catch (error) {
       toast.error('Failed to create project. Please try again.');
     }
@@ -369,7 +370,7 @@ const SelectProject: React.FC = () => {
               await projectsServices.selectProject({
                 projectId: project.id,
               });
-              await client.get('windows:closeSelector');
+              navigate('/app');
             }}
           >
             <ProjectInfo>
@@ -544,7 +545,8 @@ const SelectProject: React.FC = () => {
                         await projectsServices.selectProject({
                           projectId: project.id,
                         });
-                        await client.get('windows:closeSelector');
+                        setIsAddingProject(false);
+                        setNewProject({ name: '' });
                       }
                     } catch (error) {
                       // Show toast message instead of throwing an error


### PR DESCRIPTION
This pull request refactors the project selection and window management logic in the application, removing the dependency on Electron's `ipcMain` for window control and simplifying the handling of project selection. Key changes include the removal of the project selector window, updates to the `WindowManager` class, and adjustments to the React components to handle project selection and navigation directly.

### Window Management Refactor:
* Removed `ipcMain` handlers (`windows:openSelector` and `windows:closeSelector`) and their associated logic in `src/main/main.ts`. These handlers were previously used to manage the project selector window.
* Deleted the `createProjectWindow` function and all related logic from the `WindowManager` class, including methods for showing and closing the project selector window. [[1]](diffhunk://#diff-b8c63d880daaddb3007ce5101a0f6bd6adaeeab3a2ed23d1ac48a5d1624b36edL7-L13) [[2]](diffhunk://#diff-b8c63d880daaddb3007ce5101a0f6bd6adaeeab3a2ed23d1ac48a5d1624b36edL27-L70)

### React Component Updates:
* Refactored the `AppProvider` component to remove the fallback UI for project selection and eliminate the use of `client.get('windows:openSelector')`. Navigation to the project selector is now handled directly via React Router. [[1]](diffhunk://#diff-1a300c817549d4ced24edc3c8b3f841e2c1024a4293831ea475cba13e2bd2845L2-L10) [[2]](diffhunk://#diff-1a300c817549d4ced24edc3c8b3f841e2c1024a4293831ea475cba13e2bd2845L77-L126)
* Updated the `ProjectDetails` component to include early returns for various states (e.g., loading, no project selected, missing connection) and removed redundant checks. [[1]](diffhunk://#diff-5fbf0228717c9b9238dae3fcaa4b0cf11cf63c3a6465b4073692d173980d4a1bR51-R74) [[2]](diffhunk://#diff-5fbf0228717c9b9238dae3fcaa4b0cf11cf63c3a6465b4073692d173980d4a1bL263-L274)

### Project Selection Workflow:
* Removed the dependency on the `client` object for managing project selection in the `SelectProject` component. Navigation to the main app view is now handled using `useNavigate`. [[1]](diffhunk://#diff-d92d91e8315aa4d96001f834a5da7a0c488c41143b5f1e7262b8e411439158ecR306-L308) [[2]](diffhunk://#diff-d92d91e8315aa4d96001f834a5da7a0c488c41143b5f1e7262b8e411439158ecL372-R373)
* Simplified the logic for creating and selecting projects, ensuring smoother transitions and better user feedback.

### Code Cleanup:
* Removed unused imports and variables across multiple files, such as `client` from `src/renderer/components/menu/index.tsx` and `src/renderer/context/AppProvider.tsx`. [[1]](diffhunk://#diff-cb016c3933fb1817c683fee1d359b3df811356e78632ff65b7bf5352a1029ecbL38) [[2]](diffhunk://#diff-1a300c817549d4ced24edc3c8b3f841e2c1024a4293831ea475cba13e2bd2845L2-L10)
* Consolidated and streamlined type usage, such as adding `Project` to relevant imports in `src/renderer/screens/projectDetails/index.tsx`.…ipcMain handlers and improve project selection flow.