### PR TITLE
Enhance/getting started flow

### DIFF
--- a/src/main/services/connectors.service.ts
+++ b/src/main/services/connectors.service.ts
@@ -201,7 +201,7 @@ export default class ConnectorsService {
           name: projectName,
           databaseName:
             connection.type === 'duckdb'
-              ? connection.database_path
+              ? connection.short_database_path
               : connection.database,
           schemaName: connection.schema,
           dbType: connection.type,

--- a/src/renderer/components/connectionCards/style.tsx
+++ b/src/renderer/components/connectionCards/style.tsx
@@ -48,13 +48,18 @@ export const StyledCardContent = styled(CardContent)({
 
 export const StyledCard = styled(Card)({
   maxWidth: 345,
-  width: 240,
-  height: 252,
+  width: 280,
+  height: 280,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
   cursor: 'pointer',
   transition: 'all 0.3s ease',
   '&:hover': {
     transform: 'translateY(-4px)',
   },
+  boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
 });
 
 export const MediaImage = styled('img')({

--- a/src/renderer/components/connectionCards/style.tsx
+++ b/src/renderer/components/connectionCards/style.tsx
@@ -48,8 +48,8 @@ export const StyledCardContent = styled(CardContent)({
 
 export const StyledCard = styled(Card)({
   maxWidth: 345,
-  width: 280,
-  height: 280,
+  width: 240,
+  height: 252,
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',

--- a/src/renderer/components/connections/duckdb.tsx
+++ b/src/renderer/components/connections/duckdb.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -27,6 +27,13 @@ type Props = {
   onCancel: () => void;
 };
 
+function shortDuckdbPath(databasePath: string): string {
+  // Get the base filename from the full path
+  // Example /Users/nurilacka/sample_01.duckdb you would get sample_01 without the .duckdb extension
+  const baseName = databasePath.split('/').pop() || '';
+  return baseName.replace(/\.duckdb$/, '');
+}
+
 export const DuckDB: React.FC<Props> = ({ onCancel }) => {
   const { data: project } = useGetSelectedProject();
   const navigate = useNavigate();
@@ -48,6 +55,7 @@ export const DuckDB: React.FC<Props> = ({ onCancel }) => {
     database_path: existingConnection?.path || '',
     database: existingConnection?.database || 'main', // For compatibility
     schema: 'main', // DuckDB default schema
+    short_database_path: existingConnection?.path ? shortDuckdbPath(existingConnection.path) : '',
   });
 
   const [isTesting, setIsTesting] = React.useState(false);
@@ -109,7 +117,7 @@ export const DuckDB: React.FC<Props> = ({ onCancel }) => {
     }));
 
     setConnectionStatus('idle');
-  };
+  }
 
   const handleFileSelect = () => {
     getFiles(
@@ -157,6 +165,14 @@ export const DuckDB: React.FC<Props> = ({ onCancel }) => {
     };
     testConnection(connectionData);
   };
+
+  useEffect(() => {
+    // Update short path whenever database_path changes
+    setFormState((prev) => ({
+      ...prev,
+      short_database_path: shortDuckdbPath(prev.database_path),
+    }));
+  }, [formState.database_path]);
 
   const getIndicatorColor = () => {
     switch (connectionStatus) {

--- a/src/renderer/components/connections/duckdb.tsx
+++ b/src/renderer/components/connections/duckdb.tsx
@@ -86,30 +86,13 @@ export const DuckDB: React.FC<Props> = ({ onCancel }) => {
         const pidMatch = error.message.match(/PID: (\d+)/);
         const pid = pidMatch ? pidMatch[1] : 'unknown';
 
-        // Create a click handler for the kill command
-        const handleKillClick = () => {
-          navigator.clipboard.writeText(`kill -9 ${pid}`);
-          toast.info('Kill command copied to clipboard!');
-        };
 
         // Custom toast with kill command
         toast.error(
           <Box>
-            <Typography>Database is locked by another process.</Typography>
-            <Typography>To fix this, either:</Typography>
-            <Typography>1. Close any open DuckDB CLI sessions</Typography>
-            <Typography>
-              2. Run:{' '}
-              <Link
-                onClick={handleKillClick}
-                sx={{ cursor: 'pointer', textDecoration: 'underline' }}
-              >
-                kill -9 {pid}
-              </Link>{' '}
-              (click to copy)
-            </Typography>
+            <Typography>Database is locked by another process, pid {pid}.</Typography>
+            <Typography>Close any open DuckDB CLI sessions.</Typography>
           </Box>,
-          { autoClose: 10000 },
         );
       } else {
         toast.error(`Test failed: ${error.message}`);

--- a/src/renderer/screens/addConnection/index.tsx
+++ b/src/renderer/screens/addConnection/index.tsx
@@ -27,7 +27,7 @@ const ConnectionCardsContainer = styled(Box)`
   flex-wrap: wrap;
   gap: 32px;
   padding: 12px 0 36px;
-  max-width: 1300px;
+  max-width: 1000px;
 `;
 
 type ItemType = {

--- a/src/renderer/screens/addConnection/index.tsx
+++ b/src/renderer/screens/addConnection/index.tsx
@@ -25,8 +25,9 @@ const ConnectionCardsContainer = styled(Box)`
   display: flex;
   justify-content: start;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 32px;
   padding: 12px 0 36px;
+  max-width: 1300px;
 `;
 
 type ItemType = {

--- a/src/renderer/screens/selectProject/index.tsx
+++ b/src/renderer/screens/selectProject/index.tsx
@@ -609,7 +609,7 @@ const SelectProject: React.FC = () => {
                 />
               </SearchContainer>
               <Box sx={{ display: 'flex', gap: 1 }}>
-                {projects.length === 0 && (
+                {!projects.some(p => p.name === 'dbtstudio_getting_started') && (
                   <Tooltip title="Import getting started example project">
                     <Button
                       variant="outlined"

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -79,6 +79,7 @@ export type DatabricksConnection = Omit<
 export type DuckDBConnection = Omit<ConnectionBase, 'username' | 'password'> & {
   type: 'duckdb';
   database_path: string; // Path to .duckdb file
+  short_database_path: string;
   // No username/password needed for DuckDB
 };
 


### PR DESCRIPTION
1. Getting started is not shown if you already have a project
2. Reorganise the icons of the DB connections
2. Duckdb - fix the error message on database lock
3. Change duckdb config for Rosetta Yaml (shorten the database name)