### PR TITLE
Secure storage for cloud credentials in Cloud Explorer

### DIFF
--- a/src/main/services/cloudExplorer.service.ts
+++ b/src/main/services/cloudExplorer.service.ts
@@ -30,8 +30,8 @@ class CloudExplorerService {
     return new S3Client({
       region: config.region,
       credentials: {
-        accessKeyId: config.accessKeyId,
-        secretAccessKey: config.secretAccessKey,
+        accessKeyId: config.accessKeyId || '',
+        secretAccessKey: config.secretAccessKey || '',
       },
     });
   }
@@ -133,7 +133,7 @@ class CloudExplorerService {
 
     const credential = new StorageSharedKeyCredential(
       config.accountName,
-      config.accountKey,
+      config.accountKey || '',
     );
     const url = `https://${config.accountName}.blob.core.windows.net`;
     return new BlobServiceClient(url, credential);
@@ -242,7 +242,10 @@ class CloudExplorerService {
           expiresOn,
           protocol: SASProtocol.Https,
         },
-        new StorageSharedKeyCredential(config.accountName, config.accountKey),
+        new StorageSharedKeyCredential(
+          config.accountName,
+          config.accountKey || '',
+        ),
       ).toString();
 
       return `${blobClient.url}?${sas}`;

--- a/src/renderer/components/cloudExplorer/ConnectionForm.tsx
+++ b/src/renderer/components/cloudExplorer/ConnectionForm.tsx
@@ -36,6 +36,7 @@ import {
   useSaveConnection,
 } from '../../controllers/cloudExplorer.controller';
 import { cloudStorageImages } from '../../../../assets/connectionIcons';
+import useSecureStorage from '../../hooks/useSecureStorage';
 
 interface ConnectionFormProps {
   initialValues?: CloudConnection;
@@ -64,6 +65,14 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
   const navigate = useNavigate();
   const saveConnection = useSaveConnection();
   const testConnection = useTestCloudConnection();
+  const {
+    setCloudGcsCredential,
+    getCloudGcsCredential,
+    setCloudAwsSecret,
+    getCloudAwsSecret,
+    setCloudAzureKey,
+    getCloudAzureKey,
+  } = useSecureStorage();
 
   const [testStatus, setTestStatus] = useState<
     'idle' | 'testing' | 'success' | 'error'
@@ -116,6 +125,25 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
         accountKey: (config as AzureConfig).accountKey || '',
         connectionString: (config as AzureConfig).connectionString || '',
       });
+    }
+  }, [initialValues]);
+
+  // On edit, fetch credentials from secure storage
+  useEffect(() => {
+    if (initialValues) {
+      const { name, provider } = initialValues;
+      (async () => {
+        if (provider === 'gcs') {
+          const stored = await getCloudGcsCredential(name);
+          setFormData((prev) => ({ ...prev, credentials: stored || '' }));
+        } else if (provider === 'aws') {
+          const stored = await getCloudAwsSecret(name);
+          setFormData((prev) => ({ ...prev, secretAccessKey: stored || '' }));
+        } else if (provider === 'azure') {
+          const stored = await getCloudAzureKey(name);
+          setFormData((prev) => ({ ...prev, accountKey: stored || '' }));
+        }
+      })();
     }
   }, [initialValues]);
 
@@ -175,8 +203,8 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
     setErrorMessage('');
 
     try {
-      const config = createConfigFromFormData();
-
+      const rawConfig = createConfigFromFormData();
+      const config = rawConfig;
       // Validate config before sending
       if (!config) {
         throw new Error('Failed to create configuration object');
@@ -200,16 +228,41 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
     if (!validateForm()) return;
 
     try {
-      const config = createConfigFromFormData();
+      const rawConfig = createConfigFromFormData();
+      let finalConfig: typeof rawConfig;
+      if (formData.provider === 'gcs') {
+        await setCloudGcsCredential(formData.credentials, formData.name);
+        // Omit credentials if present
+        const config = { ...rawConfig };
+        if ('credentials' in config) {
+          delete (config as any).credentials;
+        }
+        finalConfig = config;
+      } else if (formData.provider === 'aws') {
+        await setCloudAwsSecret(formData.secretAccessKey, formData.name);
+        const config = { ...rawConfig };
+        if ('secretAccessKey' in config) {
+          delete (config as any).secretAccessKey;
+        }
+        finalConfig = config;
+      } else if (formData.provider === 'azure') {
+        await setCloudAzureKey(formData.accountKey, formData.name);
+        const config = { ...rawConfig };
+        if ('accountKey' in config) {
+          delete (config as any).accountKey;
+        }
+        finalConfig = config;
+      } else {
+        finalConfig = rawConfig;
+      }
       const connection: CloudConnection = {
         id: connectionId || uuidv4(),
         name: formData.name,
         provider: formData.provider,
-        config,
+        config: finalConfig,
         created: initialValues?.created || new Date(),
         lastUsed: new Date(),
       };
-
       await saveConnection.mutateAsync(connection);
       navigate('/app/cloud-explorer/connections');
     } catch (error) {

--- a/src/renderer/components/cloudExplorer/ExplorerBucketContent.tsx
+++ b/src/renderer/components/cloudExplorer/ExplorerBucketContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { formatDistanceToNow } from 'date-fns';
 import {
@@ -43,11 +43,9 @@ import {
   useAddRecentItem,
   usePreviewData,
 } from '../../controllers/cloudExplorer.controller';
-import type {
-  CloudProvider,
-  CloudStorageConfig,
-} from '../../../types/frontend';
+import type { CloudProvider } from '../../../types/frontend';
 import { InlineDataPreview } from './InlineDataPreview';
+import useSecureStorage from '../../hooks/useSecureStorage';
 
 interface ExplorerBucketContentProps {
   connectionId: string;
@@ -68,18 +66,50 @@ export const ExplorerBucketContent: React.FC<ExplorerBucketContentProps> = ({
     fileName: string;
     objectName: string;
   } | null>(null);
+  const [secureConfig, setSecureConfig] = useState<any | null>(null);
 
   const connectionQuery = useConnection(connectionId);
   const connection = connectionQuery.data;
+  const { getCloudAwsSecret, getCloudAzureKey, getCloudGcsCredential } =
+    useSecureStorage();
+
+  useEffect(() => {
+    const fetchSecrets = async () => {
+      if (!connection) {
+        setSecureConfig(null);
+        return;
+      }
+      const config = { ...connection.config };
+      try {
+        if (connection.provider === 'aws') {
+          const secret = await getCloudAwsSecret(connection.name);
+          (config as { secretAccessKey?: string }).secretAccessKey =
+            secret || '';
+        } else if (connection.provider === 'azure') {
+          const key = await getCloudAzureKey(connection.name);
+          (config as { accountKey?: string }).accountKey = key || '';
+        } else if (connection.provider === 'gcs') {
+          const cred = await getCloudGcsCredential(connection.name);
+          (config as { credentials?: any }).credentials = cred || '';
+        }
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to fetch secure credentials', e);
+      }
+      setSecureConfig(config);
+    };
+    fetchSecrets();
+    // Only refetch if connection changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connection]);
 
   const objectsQuery = useListObjects(
     connection?.provider as CloudProvider,
-    connection?.config as CloudStorageConfig,
+    secureConfig as any,
     bucketName,
     prefix,
-    !!connection,
+    !!connection && !!secureConfig,
   );
-
   const getDownloadUrl = useGetDownloadUrl();
   const addRecentItem = useAddRecentItem();
   const previewData = usePreviewData();
@@ -127,18 +157,17 @@ export const ExplorerBucketContent: React.FC<ExplorerBucketContentProps> = ({
       return;
     }
 
-    if (!connection) return;
+    if (!connection || !secureConfig) return;
 
     try {
       setLoadingUrls((prev) => ({ ...prev, [objectName]: true }));
 
       const url = await getDownloadUrl.mutateAsync({
         provider: connection.provider,
-        config: connection.config,
+        config: secureConfig,
         bucketName,
         objectName,
       });
-
       if (url) {
         setDownloadUrls((prev) => ({ ...prev, [objectName]: url }));
         window.open(url, '_blank');
@@ -209,7 +238,7 @@ export const ExplorerBucketContent: React.FC<ExplorerBucketContentProps> = ({
   };
 
   const handlePreview = async (objectName: string) => {
-    if (!connection) return;
+    if (!connection || !secureConfig) return;
 
     const fileName = objectName.split('/').pop() || objectName;
     setPreviewFile({
@@ -220,7 +249,7 @@ export const ExplorerBucketContent: React.FC<ExplorerBucketContentProps> = ({
     // Trigger the preview data fetch
     previewData.mutate({
       provider: connection.provider,
-      config: connection.config,
+      config: secureConfig,
       bucketName,
       objectName,
       previewType: 'sample',

--- a/src/renderer/components/cloudExplorer/ExplorerBuckets.tsx
+++ b/src/renderer/components/cloudExplorer/ExplorerBuckets.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -29,6 +29,7 @@ import type {
   CloudStorageConfig,
 } from '../../../types/frontend';
 import { cloudStorageImages } from '../../../../assets/connectionIcons';
+import useSecureStorage from '../../hooks/useSecureStorage';
 
 interface ExplorerBucketsProps {
   connectionId: string;
@@ -41,10 +42,42 @@ export const ExplorerBuckets: React.FC<ExplorerBucketsProps> = ({
   const connectionQuery = useConnection(connectionId);
   const connection = connectionQuery.data;
 
+  // Secure storage logic
+  const { getCloudAwsSecret, getCloudAzureKey, getCloudGcsCredential } =
+    useSecureStorage();
+  const [secureConfig, setSecureConfig] = useState<any | null>(null);
+
+  useEffect(() => {
+    const fetchSecrets = async () => {
+      if (!connection) {
+        setSecureConfig(null);
+        return;
+      }
+      const config = { ...connection.config };
+      try {
+        if (connection.provider === 'aws') {
+          const secret = await getCloudAwsSecret(connection.name);
+          (config as { secretAccessKey?: string }).secretAccessKey =
+            secret || '';
+        } else if (connection.provider === 'azure') {
+          const key = await getCloudAzureKey(connection.name);
+          (config as { accountKey?: string }).accountKey = key || '';
+        } else if (connection.provider === 'gcs') {
+          const cred = await getCloudGcsCredential(connection.name);
+          (config as { credentials?: any }).credentials = cred || '';
+        }
+      } catch (e) {
+        // handle error if needed
+      }
+      setSecureConfig(config);
+    };
+    fetchSecrets();
+  }, [connection]);
+
   const bucketsQuery = useListBuckets(
     connection?.provider as CloudProvider,
-    connection?.config as CloudStorageConfig,
-    !!connection,
+    secureConfig as CloudStorageConfig,
+    !!connection && !!secureConfig,
   );
 
   const buckets = bucketsQuery.data || [];

--- a/src/renderer/components/cloudExplorer/ExplorerConnections.tsx
+++ b/src/renderer/components/cloudExplorer/ExplorerConnections.tsx
@@ -34,11 +34,17 @@ import {
   useDeleteBucketConnection,
 } from '../../controllers';
 import { cloudStorageImages } from '../../../../assets/connectionIcons';
+import useSecureStorage from '../../hooks/useSecureStorage';
 
 export const ExplorerConnections: React.FC = () => {
   const navigate = useNavigate();
   const connectionsQuery = useGetCloudConnections();
   const deleteConnection = useDeleteBucketConnection();
+  const {
+    deleteCloudAwsSecret,
+    deleteCloudAzureKey,
+    deleteCloudGcsCredential,
+  } = useSecureStorage();
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [connectionToDelete, setConnectionToDelete] = useState<string | null>(
@@ -92,7 +98,19 @@ export const ExplorerConnections: React.FC = () => {
   const handleDeleteConnection = async () => {
     if (connectionToDelete) {
       try {
+        const connection = connectionsQuery.data?.find(
+          (c) => c.id === connectionToDelete,
+        );
         await deleteConnection.mutateAsync(connectionToDelete);
+        if (connection) {
+          if (connection.provider === 'aws') {
+            await deleteCloudAwsSecret(connection.name);
+          } else if (connection.provider === 'azure') {
+            await deleteCloudAzureKey(connection.name);
+          } else if (connection.provider === 'gcs') {
+            await deleteCloudGcsCredential(connection.name);
+          }
+        }
         setDeleteDialogOpen(false);
         setConnectionToDelete(null);
       } catch (error) {

--- a/src/renderer/hooks/useSecureStorage.ts
+++ b/src/renderer/hooks/useSecureStorage.ts
@@ -71,6 +71,62 @@ const useSecureStorage = () => {
     await secureStorageService.delete(`db-token-${projectName}`);
   };
 
+  // Cloud credential storage
+  const setCloudGcsCredential = async (
+    credential: string,
+    connectionName: string,
+  ): Promise<void> => {
+    await secureStorageService.set(`cloud-gcs-${connectionName}`, credential);
+  };
+
+  const getCloudGcsCredential = async (
+    connectionName: string,
+  ): Promise<string | null> => {
+    return secureStorageService.get(`cloud-gcs-${connectionName}`);
+  };
+
+  const deleteCloudGcsCredential = async (
+    connectionName: string,
+  ): Promise<void> => {
+    await secureStorageService.delete(`cloud-gcs-${connectionName}`);
+  };
+
+  const setCloudAwsSecret = async (
+    secret: string,
+    connectionName: string,
+  ): Promise<void> => {
+    await secureStorageService.set(`cloud-aws-${connectionName}`, secret);
+  };
+
+  const getCloudAwsSecret = async (
+    connectionName: string,
+  ): Promise<string | null> => {
+    return secureStorageService.get(`cloud-aws-${connectionName}`);
+  };
+
+  const deleteCloudAwsSecret = async (
+    connectionName: string,
+  ): Promise<void> => {
+    await secureStorageService.delete(`cloud-aws-${connectionName}`);
+  };
+
+  const setCloudAzureKey = async (
+    key: string,
+    connectionName: string,
+  ): Promise<void> => {
+    await secureStorageService.set(`cloud-azure-${connectionName}`, key);
+  };
+
+  const getCloudAzureKey = async (
+    connectionName: string,
+  ): Promise<string | null> => {
+    return secureStorageService.get(`cloud-azure-${connectionName}`);
+  };
+
+  const deleteCloudAzureKey = async (connectionName: string): Promise<void> => {
+    await secureStorageService.delete(`cloud-azure-${connectionName}`);
+  };
+
   return {
     setOpenAIKey,
     getOpenAIKey,
@@ -84,6 +140,15 @@ const useSecureStorage = () => {
     setDatabaseToken,
     getDatabaseToken,
     deleteDatabaseToken,
+    setCloudGcsCredential,
+    getCloudGcsCredential,
+    deleteCloudGcsCredential,
+    setCloudAwsSecret,
+    getCloudAwsSecret,
+    deleteCloudAwsSecret,
+    setCloudAzureKey,
+    getCloudAzureKey,
+    deleteCloudAzureKey,
   };
 };
 

--- a/src/types/frontend.ts
+++ b/src/types/frontend.ts
@@ -39,7 +39,10 @@ export type SecureStorageAccount =
   | 'openai-api-key'
   | `db-user-${string}`
   | `db-password-${string}`
-  | `db-token-${string}`;
+  | `db-token-${string}`
+  | `cloud-gcs-${string}`
+  | `cloud-aws-${string}`
+  | `cloud-azure-${string}`;
 
 // Cloud Explorer Types
 export interface Bucket {
@@ -64,12 +67,12 @@ export interface CloudListResult {
 export interface S3Config {
   region: string;
   accessKeyId: string;
-  secretAccessKey: string;
+  secretAccessKey?: string;
 }
 
 export interface AzureConfig {
   accountName: string;
-  accountKey: string;
+  accountKey?: string;
   connectionString?: string;
 }
 


### PR DESCRIPTION
This pull request introduces secure storage for cloud credentials and adjusts the handling of sensitive data across the application to enhance security. The changes include updates to the `CloudExplorerService`, secure storage integration in UI components, and modifications to the `useSecureStorage` hook to support cloud-specific credentials.

### Secure storage for cloud credentials:

* **`src/renderer/hooks/useSecureStorage.ts`**: Added methods for storing, retrieving, and deleting credentials for GCS, AWS, and Azure cloud providers (`setCloudGcsCredential`, `getCloudGcsCredential`, `deleteCloudGcsCredential`, etc.). [[1]](diffhunk://#diff-4399296dee60a98ebc36593f66375c924be83c330ac11688fd34df34132d320cR74-R129) [[2]](diffhunk://#diff-4399296dee60a98ebc36593f66375c924be83c330ac11688fd34df34132d320cR143-R151)
* **`src/types/frontend.ts`**: Updated `SecureStorageAccount` type to include cloud-specific credential keys and made certain fields in `S3Config` and `AzureConfig` optional to reflect secure storage usage. [[1]](diffhunk://#diff-014ecaf44d10194e0e0b68b57919daf119db474d52a31259ca56cd6dbe91121bL42-R45) [[2]](diffhunk://#diff-014ecaf44d10194e0e0b68b57919daf119db474d52a31259ca56cd6dbe91121bL67-R75)

### Updates to `CloudExplorerService`:

* **`src/main/services/cloudExplorer.service.ts`**: Modified the service to handle optional credentials (`accessKeyId`, `secretAccessKey`, `accountKey`) by providing default empty strings if not present. [[1]](diffhunk://#diff-ac5ccfac1311655a8b80c5f8330be9f43fb654b513bc472e50b07c69ed283876L33-R34) [[2]](diffhunk://#diff-ac5ccfac1311655a8b80c5f8330be9f43fb654b513bc472e50b07c69ed283876L136-R136) [[3]](diffhunk://#diff-ac5ccfac1311655a8b80c5f8330be9f43fb654b513bc472e50b07c69ed283876L245-R248)

### UI integration of secure storage:

* **`src/renderer/components/cloudExplorer/ConnectionForm.tsx`**: Integrated secure storage to fetch and save credentials when creating or editing cloud connections. Credentials are omitted from the configuration object before saving. [[1]](diffhunk://#diff-e8bbd7ac853810b29a4d77d73123bda0ab8253760e581b9bbfde26f5cd3d9897R39) [[2]](diffhunk://#diff-e8bbd7ac853810b29a4d77d73123bda0ab8253760e581b9bbfde26f5cd3d9897R68-R75) [[3]](diffhunk://#diff-e8bbd7ac853810b29a4d77d73123bda0ab8253760e581b9bbfde26f5cd3d9897R131-R149) [[4]](diffhunk://#diff-e8bbd7ac853810b29a4d77d73123bda0ab8253760e581b9bbfde26f5cd3d9897L178-R207) [[5]](diffhunk://#diff-e8bbd7ac853810b29a4d77d73123bda0ab8253760e581b9bbfde26f5cd3d9897L203-L212)
* **`src/renderer/components/cloudExplorer/ExplorerBucketContent.tsx`**: Added logic to retrieve secure credentials and use them for operations like listing objects and generating download URLs. [[1]](diffhunk://#diff-0f36cbdb7ef1b2b41dd17a1d470fc8633544f78a29bbf6a6b1d45031cdddeb1bL1-R1) [[2]](diffhunk://#diff-0f36cbdb7ef1b2b41dd17a1d470fc8633544f78a29bbf6a6b1d45031cdddeb1bL46-R48) [[3]](diffhunk://#diff-0f36cbdb7ef1b2b41dd17a1d470fc8633544f78a29bbf6a6b1d45031cdddeb1bR69-L82) [[4]](diffhunk://#diff-0f36cbdb7ef1b2b41dd17a1d470fc8633544f78a29bbf6a6b1d45031cdddeb1bL130-L141) [[5]](diffhunk://#diff-0f36cbdb7ef1b2b41dd17a1d470fc8633544f78a29bbf6a6b1d45031cdddeb1bL212-R241) [[6]](diffhunk://#diff-0f36cbdb7ef1b2b41dd17a1d470fc8633544f78a29bbf6a6b1d45031cdddeb1bL223-R252)
* **`src/renderer/components/cloudExplorer/ExplorerBuckets.tsx`**: Updated to fetch and use secure credentials for listing buckets. [[1]](diffhunk://#diff-b0d10507764fc5ec4acfa2f905c98aaa4243b17553c1055ca9159e0260cb2ecaL1-R1) [[2]](diffhunk://#diff-b0d10507764fc5ec4acfa2f905c98aaa4243b17553c1055ca9159e0260cb2ecaR32) [[3]](diffhunk://#diff-b0d10507764fc5ec4acfa2f905c98aaa4243b17553c1055ca9159e0260cb2ecaR45-R80)
* **`src/renderer/components/cloudExplorer/ExplorerConnections.tsx`**: Enhanced connection deletion to also remove associated secure credentials. [[1]](diffhunk://#diff-e4d29c36ff3049a95e9be82447c15e4f8f149c8879487232b94ba4504c5e4aa9R37-R47) [[2]](diffhunk://#diff-e4d29c36ff3049a95e9be82447c15e4f8f149c8879487232b94ba4504c5e4aa9R101-R113)…m, ExplorerBuckets, and ExplorerBucketContent components