### PR TITLE
Fix/example project configuration

### DIFF
--- a/src/main/services/connectors.service.ts
+++ b/src/main/services/connectors.service.ts
@@ -48,6 +48,19 @@ export default class ConnectorsService {
   }
 
   /**
+   * Find a connection by name (case-insensitive)
+   */
+  static async findConnectionByName(
+    name: string,
+  ): Promise<ConnectionModel | undefined> {
+    const connections = await this.loadConnections();
+    return connections.find(
+      (conn) =>
+        conn.connection.name.toLowerCase().trim() === name.toLowerCase().trim(),
+    );
+  }
+
+  /**
    * Save a new connection, allowing reserved names for Getting Started template
    */
   static async saveNewConnectionForTemplate(
@@ -182,10 +195,20 @@ export default class ConnectorsService {
       const isTemplateConnection =
         connection.name.toLowerCase().trim() === 'dbt connection';
       if (isTemplateConnection) {
-        connectionId = await this.saveNewConnectionForTemplate(
-          connection,
-          true,
+        // Check if a connection with the reserved name already exists
+        const existingConnection = await this.findConnectionByName(
+          connection.name,
         );
+        if (existingConnection) {
+          // Reuse existing connection for the starter project
+          connectionId = existingConnection.id;
+        } else {
+          // Create new connection if none exists
+          connectionId = await this.saveNewConnectionForTemplate(
+            connection,
+            true,
+          );
+        }
       } else {
         connectionId = await this.saveNewConnection(connection);
       }
@@ -200,6 +223,11 @@ export default class ConnectorsService {
 
       await this.loadConfigurations(currentProject.id);
     }
+
+    if (!connectionId) {
+      throw new Error('Failed to create or find connection');
+    }
+
     return connectionId;
   }
 


### PR DESCRIPTION
This pull request enhances the `ConnectorsService` to improve handling of connection creation, especially for reserved template connections, and introduces a new utility method for finding connections by name. The changes also include a fix for DuckDB database name formatting.

**Connection management improvements:**

* Added a new static method `findConnectionByName` to allow searching for a connection by name in a case-insensitive manner.
* Updated the logic for handling the reserved "dbt connection" name: the service now checks if a connection with this name already exists and reuses it for the starter project, instead of always creating a new one.
* Added error handling to throw an exception if a connection could not be created or found, ensuring robustness in connection creation workflows.

**Database name formatting:**

* Fixed the DuckDB database name assignment to remove the `.duckdb` file extension when setting up the connection, ensuring cleaner database names in project configurations.