### PR TITLE
feat: Enable custom schema support for DuckDB connections

### DIFF
--- a/src/main/extractor/duckdb.extractor.ts
+++ b/src/main/extractor/duckdb.extractor.ts
@@ -5,8 +5,11 @@ import { Column, Table } from '../../types/backend';
 export default class DuckDBSchemaExtractor {
   private database_path: string;
 
-  constructor(config: { database_path: string }) {
+  private schema: string;
+
+  constructor(config: { database_path: string; schema?: string }) {
     this.database_path = config.database_path;
+    this.schema = config.schema || 'main';
   }
 
   private async executeQuery(query: string): Promise<any[]> {
@@ -16,6 +19,23 @@ export default class DuckDBSchemaExtractor {
     try {
       instance = await DuckDBInstance.create(this.database_path);
       connection = await instance.connect();
+
+      // Set schema context if not 'main'
+      if (this.schema && this.schema !== 'main') {
+        try {
+          await connection.run(`USE ${this.schema}`);
+        } catch (schemaError: any) {
+          // If schema doesn't exist, throw a clear error
+          if (
+            schemaError.message?.includes('does not exist') ||
+            schemaError.message?.includes('not found')
+          ) {
+            throw new Error(
+              `Schema '${this.schema}' does not exist in the DuckDB database.`,
+            );
+          }
+        }
+      }
 
       const result = await connection.run(query);
       return await result.getRows();
@@ -53,7 +73,7 @@ export default class DuckDBSchemaExtractor {
       const rows = await this.executeQuery(`
         SELECT table_name
         FROM information_schema.tables
-        WHERE table_schema = 'main'
+        WHERE table_schema = '${this.schema}'
           AND table_type = 'BASE TABLE'
       `);
       return rows
@@ -86,7 +106,7 @@ export default class DuckDBSchemaExtractor {
       const rows = await this.executeQuery(`
         SELECT table_name
         FROM information_schema.tables
-        WHERE table_schema = 'main'
+        WHERE table_schema = '${this.schema}'
           AND table_type = 'VIEW'
       `);
       return rows
@@ -113,7 +133,7 @@ export default class DuckDBSchemaExtractor {
           column_default
         FROM information_schema.columns
         WHERE table_name = '${tableName}'
-          AND table_schema = 'main'
+          AND table_schema = '${this.schema}'
         ORDER BY ordinal_position
       `);
 
@@ -201,7 +221,7 @@ export default class DuckDBSchemaExtractor {
         allTables.push({
           name: tableName,
           type: 'TABLE',
-          schema: 'main',
+          schema: this.schema,
           columns,
         });
       } catch {
@@ -215,7 +235,7 @@ export default class DuckDBSchemaExtractor {
         allTables.push({
           name: viewName,
           type: 'VIEW',
-          schema: 'main',
+          schema: this.schema,
           columns,
         });
       } catch {

--- a/src/main/services/projects.service.ts
+++ b/src/main/services/projects.service.ts
@@ -940,6 +940,7 @@ export default class ProjectsService {
   static async extractDuckDBSchema(connection: DuckDBConnection) {
     const extractor = new DuckDBExtractor({
       database_path: connection.database_path,
+      schema: connection.schema,
     });
 
     const schema = await extractor.extractSchema();

--- a/src/main/utils/connectors.ts
+++ b/src/main/utils/connectors.ts
@@ -464,6 +464,7 @@ export async function testDuckDBConnection(
     connection = await instance.connect();
 
     try {
+      // First test basic connection
       const result = await connection.run('SELECT 1 as connection_test');
       const rows = await result.getRows();
 
@@ -478,8 +479,54 @@ export async function testDuckDBConnection(
         }
       }
 
+      if (!success) {
+        return false;
+      }
+
+      // If schema is specified and not 'main', validate it exists
+      if (config.schema && config.schema !== 'main') {
+        try {
+          const schemaQuery = `SELECT schema_name FROM information_schema.schemata WHERE schema_name = '${config.schema}'`;
+          const schemaResult = await connection.run(schemaQuery);
+          const schemaRows = await schemaResult.getRows();
+
+          if (schemaRows.length === 0) {
+            throw new Error(
+              `Schema '${config.schema}' does not exist in the DuckDB database. Available schemas can be viewed with: SHOW SCHEMAS;`,
+            );
+          }
+        } catch (schemaError: any) {
+          // If information_schema doesn't work, try alternative approach
+          if (schemaError.message?.includes('does not exist')) {
+            throw schemaError;
+          }
+
+          try {
+            // Try to use the schema directly
+            await connection.run(`USE ${config.schema}`);
+          } catch (useError: any) {
+            if (
+              useError.message?.includes('does not exist') ||
+              useError.message?.includes('not found')
+            ) {
+              throw new Error(
+                `Schema '${config.schema}' does not exist in the DuckDB database. Available schemas can be viewed with: SHOW SCHEMAS;`,
+              );
+            }
+            // If it's some other error, continue - the schema might exist but have other issues
+          }
+        }
+      }
+
       return success;
-    } catch (queryError) {
+    } catch (queryError: any) {
+      // Re-throw schema validation errors
+      if (
+        queryError.message?.includes('Schema') &&
+        queryError.message?.includes('does not exist')
+      ) {
+        throw queryError;
+      }
       return false;
     }
   } catch (error: any) {
@@ -542,6 +589,24 @@ export const executeDuckDBQuery = async (
   try {
     instance = await DuckDBInstance.create(config.database_path);
     connection = await instance.connect();
+
+    // Set schema context if specified and not 'main'
+    if (config.schema && config.schema !== 'main') {
+      try {
+        await connection.run(`USE ${config.schema}`);
+      } catch (schemaError: any) {
+        if (
+          schemaError.message?.includes('does not exist') ||
+          schemaError.message?.includes('not found')
+        ) {
+          return {
+            success: false,
+            error: `Schema '${config.schema}' does not exist in the DuckDB database. Available schemas can be viewed with: SHOW SCHEMAS;`,
+          };
+        }
+        // If it's some other error, continue - might be a permission issue but schema exists
+      }
+    }
 
     const result = await connection.run(query);
     const rows = await result.getRows();

--- a/src/renderer/components/connections/duckdb.tsx
+++ b/src/renderer/components/connections/duckdb.tsx
@@ -57,7 +57,7 @@ export const DuckDB: React.FC<Props> = ({
     name: existingConnection?.name || 'DuckDB Connection',
     database_path: existingConnection?.database_path || '',
     database: existingConnection?.database || 'main',
-    schema: 'main',
+    schema: existingConnection?.schema || 'main',
     short_database_path: existingConnection?.database_path
       ? shortDuckdbPath(existingConnection.database_path)
       : '',
@@ -306,8 +306,8 @@ export const DuckDB: React.FC<Props> = ({
           value={formState.schema}
           onChange={handleChange}
           fullWidth
-          helperText="DuckDB schema (default: main)"
-          disabled
+          helperText="DuckDB schema name (default: main). Schema must exist in the database."
+          placeholder="main"
         />
 
         <Box


### PR DESCRIPTION
- Enable schema field in DuckDB connection form (previously disabled)
- Add schema validation during connection testing to verify schema exists
- Update DuckDB schema extractor to work with custom schemas instead of hardcoded 'main'
- Enhance query execution to set proper schema context using USE statement
- Provide clear error messages when specified schema doesn't exist
- Update schema extraction service to pass schema parameter to extractor
- Maintain backward compatibility with existing 'main' schema connections