### PR TITLE
Revert "Add auto-completion provider to code editor"

### DIFF
--- a/src/renderer/components/editor/codeEditor.tsx
+++ b/src/renderer/components/editor/codeEditor.tsx
@@ -16,7 +16,6 @@ export const CodeEditor = ({
   theme,
   onChange,
   readOnly = false,
-  onMount,
 }: {
   content: string;
   originalContent: string | null;
@@ -24,7 +23,6 @@ export const CodeEditor = ({
   theme: string;
   onChange: OnChange;
   readOnly?: boolean;
-  onMount?: (editor: IStandaloneCodeEditor) => void;
 }) => {
   const [isMounted, setIsMounted] = React.useState(false);
   const editorRef = useRef<IStandaloneCodeEditor | null>(null);
@@ -66,9 +64,6 @@ export const CodeEditor = ({
 
     decorationsRef.current?.clear();
     decorationsRef.current = null;
-
-    // Call the onMount callback if provided
-    onMount?.(editor);
 
     setTimeout(() => {
       setIsMounted(true);

--- a/src/renderer/components/editor/index.tsx
+++ b/src/renderer/components/editor/index.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import { OnChange, loader } from '@monaco-editor/react';
-import {
-  useTheme,
-  IconButton,
-  Menu,
-  MenuItem,
-  ListItemIcon,
-  ListItemText,
-  Typography,
-} from '@mui/material';
-import { Undo, Redo, VerticalSplit, Edit } from '@mui/icons-material';
+import { useTheme, IconButton, Tooltip } from '@mui/material';
+import { VerticalSplit } from '@mui/icons-material';
 import { isEditableFile } from '../../helpers/utils';
 import {
   useGetFileDiff,
@@ -50,8 +42,6 @@ export const Editor = ({
 
   const isFileEditable = isEditableFile(filePath);
   const [showDiffView, setShowDiffView] = React.useState(false);
-  const [menuAnchor, setMenuAnchor] = React.useState<HTMLElement | null>(null);
-  const editorRef = React.useRef<any>(null);
   const debounceTimer = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -80,145 +70,17 @@ export const Editor = ({
     }
   };
 
-  const handleUndo = () => {
-    if (editorRef.current) {
-      editorRef.current.trigger('keyboard', 'undo', null);
-    }
-    setMenuAnchor(null);
-  };
-
-  const handleRedo = () => {
-    if (editorRef.current) {
-      editorRef.current.trigger('keyboard', 'redo', null);
-    }
-    setMenuAnchor(null);
-  };
-
-  const handleToggleDiff = () => {
-    setShowDiffView((prev) => !prev);
-    setMenuAnchor(null);
-  };
-
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setMenuAnchor(event.currentTarget);
-  };
-
-  const handleMenuClose = () => {
-    setMenuAnchor(null);
-  };
-
-  // Create menu items based on available features
-  const menuItems = React.useMemo(() => {
-    const items = [];
-
-    if (originalContent) {
-      items.push({
-        icon: <VerticalSplit sx={{ fontSize: 16 }} />,
-        name: showDiffView ? 'Hide Git Diff' : 'Show Git Diff',
-        onClick: handleToggleDiff,
-      });
-    }
-
-    if (isFileEditable) {
-      items.push(
-        {
-          icon: <Undo sx={{ fontSize: 16 }} />,
-          name: 'Undo',
-          shortcut: 'Ctrl+Z',
-          onClick: handleUndo,
-        },
-        {
-          icon: <Redo sx={{ fontSize: 16 }} />,
-          name: 'Redo',
-          shortcut: 'Ctrl+Y',
-          onClick: handleRedo,
-        },
-      );
-    }
-
-    return items;
-  }, [isFileEditable, originalContent, showDiffView]);
-
   return (
     <Container>
-      {filePath && (
-        <>
+      {originalContent && (
+        <Tooltip title="Compare Changes">
           <IconButton
-            size="small"
-            onClick={handleMenuOpen}
-            sx={{
-              position: 'absolute',
-              top: 8,
-              right: 8,
-              zIndex: 1000,
-              width: 28,
-              height: 28,
-              backgroundColor: theme.palette.background.paper,
-              border: `1px solid ${theme.palette.divider}`,
-              '&:hover': {
-                backgroundColor: theme.palette.action.hover,
-              },
-            }}
+            onClick={() => setShowDiffView((prev) => !prev)}
+            sx={{ position: 'absolute', right: 30, top: 0, zIndex: 999 }}
           >
-            <Edit sx={{ fontSize: 14 }} />
+            <VerticalSplit sx={{ color: 'primary.main' }} />
           </IconButton>
-          {menuItems.length > 0 && (
-            <Menu
-              anchorEl={menuAnchor}
-              open={Boolean(menuAnchor)}
-              onClose={handleMenuClose}
-              anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'right',
-              }}
-              transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              sx={{
-                '& .MuiPaper-root': {
-                  minWidth: 160,
-                },
-                '& .MuiMenuItem-root': {
-                  fontSize: '0.75rem',
-                  minHeight: 28,
-                  paddingY: 0.25,
-                  paddingX: 0.75,
-                },
-                '& .MuiListItemIcon-root': {
-                  minWidth: 24,
-                },
-                '& .MuiListItemText-root': {
-                  margin: 0,
-                  '& .MuiTypography-root': {
-                    fontSize: '0.75rem',
-                  },
-                },
-              }}
-            >
-              {menuItems.map((item) => (
-                <MenuItem key={item.name} onClick={item.onClick}>
-                  <ListItemIcon sx={{ minWidth: 24 }}>{item.icon}</ListItemIcon>
-                  <ListItemText
-                    primary={item.name}
-                    slotProps={{
-                      primary: { fontSize: '0.75rem' },
-                    }}
-                  />
-                  {item.shortcut && (
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ ml: 0.5, fontSize: '0.7rem' }}
-                    >
-                      {item.shortcut}
-                    </Typography>
-                  )}
-                </MenuItem>
-              ))}
-            </Menu>
-          )}
-        </>
+        </Tooltip>
       )}
       {showDiffView && !isLoadingFileStatus && (
         <DiffView
@@ -236,9 +98,6 @@ export const Editor = ({
           theme={monacoTheme}
           onChange={handleChange}
           readOnly={!isFileEditable}
-          onMount={(editor) => {
-            editorRef.current = editor;
-          }}
         />
       )}
     </Container>


### PR DESCRIPTION
This reverts commit b75ad5c7c84ad6f8fea320f56e2f385272255067.

The auto-completion provider implementation was causing:
- Frequent re-renders of the Monaco editor
- Loss of focus during typing
- Poor user experience with editor interactions

Reverting to the stable version without auto-completion until a more performant implementation can be developed.