### PR TITLE
feat(rename): implement file/folder rename across main and renderer

### DIFF
--- a/src/main/ipcHandlers/projects.ipcHandlers.ts
+++ b/src/main/ipcHandlers/projects.ipcHandlers.ts
@@ -146,6 +146,19 @@ const registerProjectHandlers = () => {
     },
   );
 
+  ipcMain.handle(
+    'project:renamePath',
+    async (
+      _event,
+      body: {
+        path: string;
+        newName: string;
+      },
+    ) => {
+      return ProjectsService.renamePath(body);
+    },
+  );
+
   ipcMain.handle('project:selected', async () => {
     return ProjectsService.getSelectedProject();
   });

--- a/src/main/services/projects.service.ts
+++ b/src/main/services/projects.service.ts
@@ -847,6 +847,17 @@ export default class ProjectsService {
     return createNewFile(filePath, name, content);
   }
 
+  static async renamePath({
+    path: source,
+    newName,
+  }: {
+    path: string;
+    newName: string;
+  }): Promise<string> {
+    const { renamePath } = await import('../utils/fileHelper');
+    return renamePath(source, newName);
+  }
+
   static async selectProject({ projectId }: { projectId: string }) {
     const project = await this.getProject(projectId);
     await updateDatabase<'selectedProject'>('selectedProject', project);

--- a/src/main/utils/fileHelper.ts
+++ b/src/main/utils/fileHelper.ts
@@ -240,6 +240,20 @@ export const deleteItem = async (targetPath: string) => {
   }
 };
 
+export const renamePath = async (source: string, newName: string) => {
+  if (!fs.existsSync(source)) {
+    throw new Error(`Source path does not exist: ${source}`);
+  }
+  const dir = path.dirname(source);
+  const target = path.join(dir, newName);
+  // If target exists, throw to avoid accidental overwrite
+  if (fs.existsSync(target)) {
+    throw new Error(`Target already exists: ${target}`);
+  }
+  await promises.rename(source, target);
+  return target;
+};
+
 export const createZipArchive = async (
   sourceDir: string,
   zipFilePath: string,

--- a/src/renderer/components/fileTreeViewer/RenderTree.tsx
+++ b/src/renderer/components/fileTreeViewer/RenderTree.tsx
@@ -20,11 +20,21 @@ import {
   CreateNewFolder,
   NoteAdd,
   Archive,
+  DriveFileRenameOutline,
+  Folder,
 } from '@mui/icons-material';
+import { toast } from 'react-toastify';
+
 import { TreeItems } from './TreeItems';
 import { FileNode } from '../../../types/backend';
-import { ActionsContainer, LabelContainer } from './styles';
+import {
+  ActionsContainer,
+  LabelContainer,
+  RenameInput,
+  StyledTreeItem,
+} from './styles';
 import { projectsServices } from '../../services';
+import { FileIcon } from '../fileIcon';
 
 type Props = {
   node: FileNode;
@@ -77,6 +87,40 @@ const RenderTree: React.FC<Props> = ({
   const [menuPosition, setMenuPosition] =
     React.useState<null | PopoverPosition>(null);
 
+  const [renameOpen, setRenameOpen] = React.useState(false);
+  const [renameValue, setRenameValue] = React.useState<string>('');
+  const renameInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Ensure input receives focus and selects current text when renaming starts
+  React.useEffect(() => {
+    if (renameOpen && renameInputRef.current) {
+      // Focus and select the whole filename for quick overwrite
+      renameInputRef.current.focus();
+      renameInputRef.current.select();
+    }
+  }, [renameOpen]);
+
+  const saveRename = React.useCallback(async () => {
+    const newName = renameValue.trim();
+    if (!newName || newName === node.name) {
+      setRenameOpen(false);
+      return;
+    }
+    try {
+      await projectsServices.renamePath({
+        path: node.path,
+        newName,
+      });
+      if (typeof onRefresh === 'function') {
+        onRefresh();
+      }
+    } catch (e: any) {
+      toast.error(`Rename failed: ${e?.message || 'Unknown error'}`);
+    } finally {
+      setRenameOpen(false);
+    }
+  }, [renameValue, node.path, node.name, onRefresh]);
+
   const fileStatus = fileStatuses[node.path];
   const labelColor = getColorByStatus(fileStatus);
 
@@ -110,56 +154,109 @@ const RenderTree: React.FC<Props> = ({
       onContextMenu={handleMenuOpen}
       label={
         <LabelContainer>
-          {label}
-          <ActionsContainer className="actions-container">
-            {node.path === projectPath && (
-              <IconButton
-                size="small"
-                edge="end"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  if (typeof onRefresh === 'function') {
-                    onRefresh();
+          {renameOpen ? (
+            <StyledTreeItem
+              onMouseDown={(e) => {
+                // Keep focus on input when clicking outside the input,
+                // but allow normal selection/caret behavior when clicking the input itself.
+                const target = e.target as HTMLElement;
+                const isInput =
+                  target.tagName === 'INPUT' || !!target.closest('input');
+                if (!isInput) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  renameInputRef.current?.focus();
+                }
+              }}
+            >
+              {node.type === 'folder' ? (
+                <Folder
+                  sx={{
+                    color: node.name === '.git' ? '#aabdefff' : '#5f89f4',
+                    width: 14,
+                    height: 14,
+                    pointerEvents: 'none',
+                  }}
+                />
+              ) : (
+                <span style={{ pointerEvents: 'none', display: 'inline-flex' }}>
+                  <FileIcon fileName={node.name} />
+                </span>
+              )}
+              <RenameInput
+                ref={renameInputRef}
+                value={renameValue}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setRenameValue(e.target.value)
+                }
+                onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                  e.stopPropagation();
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    saveRename();
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    setRenameOpen(false);
                   }
-                  handleMenuClose();
                 }}
-              >
-                <Tooltip title="Refresh">
-                  <RefreshOutlined fontSize="small" />
-                </Tooltip>
-              </IconButton>
-            )}
-            {node.type === 'folder' && (
-              <>
+                onBlur={() => setRenameOpen(false)}
+                style={{ flex: 1 }}
+              />
+            </StyledTreeItem>
+          ) : (
+            label
+          )}
+          {!renameOpen && (
+            <ActionsContainer className="actions-container">
+              {node.path === projectPath && (
                 <IconButton
                   size="small"
                   edge="end"
                   onClick={(event) => {
                     event.stopPropagation();
-                    onNewFile(node.path);
+                    if (typeof onRefresh === 'function') {
+                      onRefresh();
+                    }
                     handleMenuClose();
                   }}
                 >
-                  <Tooltip title="Create new file">
-                    <NoteAddOutlined fontSize="small" />
+                  <Tooltip title="Refresh">
+                    <RefreshOutlined fontSize="small" />
                   </Tooltip>
                 </IconButton>
-                <IconButton
-                  size="small"
-                  edge="end"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onNewFolder(node.path);
-                    handleMenuClose();
-                  }}
-                >
-                  <Tooltip title="Create new folder">
-                    <CreateNewFolderOutlined fontSize="small" />
-                  </Tooltip>
-                </IconButton>
-              </>
-            )}
-          </ActionsContainer>
+              )}
+              {node.type === 'folder' && (
+                <>
+                  <IconButton
+                    size="small"
+                    edge="end"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onNewFile(node.path);
+                      handleMenuClose();
+                    }}
+                  >
+                    <Tooltip title="Create new file">
+                      <NoteAddOutlined fontSize="small" />
+                    </Tooltip>
+                  </IconButton>
+                  <IconButton
+                    size="small"
+                    edge="end"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onNewFolder(node.path);
+                      handleMenuClose();
+                    }}
+                  >
+                    <Tooltip title="Create new folder">
+                      <CreateNewFolderOutlined fontSize="small" />
+                    </Tooltip>
+                  </IconButton>
+                </>
+              )}
+            </ActionsContainer>
+          )}
           <Menu
             anchorReference="anchorPosition"
             open={Boolean(menuPosition)}
@@ -170,6 +267,20 @@ const RenderTree: React.FC<Props> = ({
             }
             onClose={handleMenuClose}
           >
+            <MenuItem
+              onClick={(event) => {
+                event.stopPropagation();
+                setRenameValue(node.name);
+                setRenameOpen(true);
+                handleMenuClose();
+              }}
+            >
+              <ListItemIcon>
+                <DriveFileRenameOutline fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>Rename</ListItemText>
+            </MenuItem>
+
             <MenuItem
               onClick={(event) => {
                 event.stopPropagation();
@@ -288,6 +399,7 @@ const RenderTree: React.FC<Props> = ({
           onNewFile={onNewFile}
           projectName={projectName}
           projectPath={projectPath}
+          onRefresh={onRefresh}
           onCopyPath={onCopyPath}
           onPastePath={onPastePath}
           copyPathData={copyPathData}

--- a/src/renderer/components/fileTreeViewer/styles.tsx
+++ b/src/renderer/components/fileTreeViewer/styles.tsx
@@ -1,4 +1,5 @@
 import { styled, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import { SimpleTreeView } from '@mui/x-tree-view';
 
 export const Container = styled('div')(() => ({
@@ -34,6 +35,10 @@ export const StyledTreeView = styled(SimpleTreeView)(() => ({
   height: 'calc(100% - 60px)',
   overflowY: 'auto',
   paddingBottom: 10,
+  // Hide the icon area while renaming to avoid leading glyph before the input
+  '& .renaming .MuiTreeItem-iconContainer': {
+    display: 'none',
+  },
 }));
 
 export const LabelContainer = styled('div')(() => ({
@@ -54,4 +59,32 @@ export const ActionsContainer = styled('div')(() => ({
   transition: 'opacity 0.2s ease-in-out',
   position: 'absolute',
   right: 0,
+}));
+
+export const RenameInput = styled('input')(({ theme }) => ({
+  // Inherit typography and colors from the tree label
+  font: 'inherit',
+  fontSize: 14,
+  lineHeight: 1.0,
+  color: theme.palette.text.primary,
+  backgroundColor: 'transparent',
+  // Sizing and spacing similar to small TextField input
+  padding: '2px 6px',
+  borderRadius: theme.shape.borderRadius,
+  border: 'none',
+  width: '100%',
+  maxWidth: 240,
+  boxSizing: 'border-box',
+  // Remove default outline and use theme-focused ring
+  outline: 'none',
+  caretColor: theme.palette.text.primary,
+  transition: 'none',
+  '::placeholder': {
+    color: alpha(theme.palette.text.primary, 0.5),
+  },
+  '&:hover': {},
+  '&:focus': {
+    outline: 'none',
+    boxShadow: 'none',
+  },
 }));

--- a/src/renderer/services/projects.service.ts
+++ b/src/renderer/services/projects.service.ts
@@ -206,6 +206,20 @@ export const deleteItem = async (body: { filePath: string }): Promise<void> => {
   return data;
 };
 
+export const renamePath = async (body: {
+  path: string;
+  newName: string;
+}): Promise<string> => {
+  const { data } = await client.post<
+    {
+      path: string;
+      newName: string;
+    },
+    string
+  >('project:renamePath', body);
+  return data;
+};
+
 export const selectProject = async (body: {
   projectId: string;
 }): Promise<void> => {

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -45,6 +45,7 @@ export type ProjectChannels =
   | 'project:updateQuery'
   | 'project:getQuery'
   | 'project:chooseDir'
+  | 'project:renamePath'
   | 'project:downloadSeed';
 
 export type ConnectorChannels =


### PR DESCRIPTION
Add end-to-end rename support with IPC integration, filesystem operation, and UI/UX wiring.

Main process:
- Add rename IPC handler in src/main/ipcHandlers/projects.ipcHandlers.ts
- Implement rename logic in src/main/services/projects.service.ts
- Reuse helpers and validation in src/main/utils/fileHelper.ts (conflict checks, path resolution, safe rename)
- Return updated metadata to renderer and surface errors

Renderer:
- Wire rename action in src/renderer/components/fileTreeViewer/RenderTree.tsx (inline edit / context menu)
- Style tweaks for editable state in src/renderer/components/fileTreeViewer/styles.tsx
- Add projects service call in src/renderer/services/projects.service.ts to invoke main IPC
- Update tree state after success; show error feedback on failure

Types:
- Extend src/types/ipc.ts with request/response types and channel for rename

Notes:
- Handles both files and folders
- Prevents overwriting existing targets and invalid names
- Provides user feedback on errors