### PR TITLE
feat(projects): handle missing Rosetta model.yaml gracefully and guid…

### DIFF
--- a/src/main/services/projects.service.ts
+++ b/src/main/services/projects.service.ts
@@ -1059,11 +1059,22 @@ export default class ProjectsService {
       project.name,
       'model.yaml',
     );
-    const res = await fs.promises.readFile(rosettaModelYamlPath, 'utf8');
-    const data = yaml.load(res) as { tables: Table[]; views: Table[] };
-    const tables = data?.tables ?? [];
-    const views = data?.views ?? [];
-    return [...tables, ...views];
+
+    try {
+      // If the file does not exist, return an empty list instead of throwing
+      if (!fs.existsSync(rosettaModelYamlPath)) {
+        return [];
+      }
+
+      const res = await fs.promises.readFile(rosettaModelYamlPath, 'utf8');
+      const data = yaml.load(res) as { tables: Table[]; views: Table[] };
+      const tables = data?.tables ?? [];
+      const views = data?.views ?? [];
+      return [...tables, ...views];
+    } catch {
+      // On any error (e.g. parse, permissions), fail gracefully
+      return [];
+    }
   }
 
   static zipDirectory = async (sourcePath: string) => {

--- a/src/renderer/screens/projectDetails/index.tsx
+++ b/src/renderer/screens/projectDetails/index.tsx
@@ -181,6 +181,15 @@ const ProjectDetails: React.FC = () => {
   ) => {
     const fileName = await getFileName(filePath);
     const tables = await projectsServices.extractSchemaFromModelYaml(_project);
+    // If Rosetta model.yaml is missing or empty, notify the user gracefully
+    if (!tables || tables.length === 0) {
+      const modelName = fileName.replace(/\.sql$/i, '');
+      const { schema, table } = utils.extractSchemaAndTable(fileName);
+      const expectedModel = schema && table ? `${schema}.${table}` : modelName;
+      toast.info(
+        `AI context incomplete: database schema missing. Run Rosetta → Raw layer to generate rosetta/${_project.name}/model.yaml (should include "${expectedModel}"). Then try again.`,
+      );
+    }
     const { schema, table } = utils.extractSchemaAndTable(fileName);
 
     const tableStructure = tables.find(


### PR DESCRIPTION

This pull request improves the robustness and user experience of the schema extraction flow in the project details screen. The main changes ensure that missing or unreadable `model.yaml` files do not cause errors and instead provide clear feedback to the user.

**Error handling and user feedback improvements:**

* The `extractSchemaFromModelYaml` method in `ProjectsService` now returns an empty list instead of throwing an error if the `model.yaml` file is missing or cannot be read, ensuring graceful failure in edge cases.
* In the `ProjectDetails` React component, users are notified with a friendly toast message if the Rosetta `model.yaml` is missing or empty, including instructions on how to generate it and what model name is expected.