### PR TITLE
feat: add terminal command history with keyboard recall

### DIFF
--- a/src/renderer/components/terminal/terminal.tsx
+++ b/src/renderer/components/terminal/terminal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Typography, useColorScheme, useTheme } from '@mui/material';
 import { toast } from 'react-toastify';
 import AnsiToHtml from 'ansi-to-html';
-import { useCli } from '../../hooks';
+import { useCli, useCommandHistory } from '../../hooks';
 import { OutputBox, StyledInput, TerminalContainer, InputLine } from './styles';
 import { useGetSettings } from '../../controllers';
 import { Project } from '../../../types/backend';
@@ -17,7 +17,9 @@ export const Terminal: React.FC<Props> = ({ project }) => {
   const { output, error, runCommandAsync, isRunning, clearOutput } = useCli();
   const [command, setCommand] = React.useState('');
   const outputRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
   const { data: settings } = useGetSettings();
+  const { record, getPrev, getNext, resetPointer } = useCommandHistory();
 
   // Theme-based terminal colors using Material UI theme
   const getTerminalColors = (themeMode: string | undefined) => {
@@ -71,9 +73,25 @@ export const Terminal: React.FC<Props> = ({ project }) => {
     }
   }, [output, error]);
 
+  const moveCaretToEnd = React.useCallback((value: string) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.setTimeout(() => {
+      if (!inputRef.current) {
+        return;
+      }
+      const { length } = value;
+      inputRef.current.focus();
+      inputRef.current.setSelectionRange(length, length);
+    }, 0);
+  }, []);
+
   const handleSendCommand = () => {
-    if (command.trim()) {
-      let newCommand = command.trim();
+    const originalCommand = command.trim();
+    if (originalCommand) {
+      let newCommand = originalCommand;
 
       const allowedCommands = ['rosetta', 'dbt', 'git', 'python'];
       const isAllowed = allowedCommands.some((cmd) =>
@@ -82,6 +100,14 @@ export const Terminal: React.FC<Props> = ({ project }) => {
 
       if (!isAllowed) {
         toast.error('Only rosetta, dbt, git, and python commands are allowed!');
+        return;
+      }
+
+      const [baseCommand, ...rest] = originalCommand.split(/\s+/);
+      if (baseCommand === 'python' && rest.length === 0) {
+        toast.error(
+          'Interactive Python sessions are not supported. Please provide a script or arguments.',
+        );
         return;
       }
 
@@ -109,15 +135,45 @@ export const Terminal: React.FC<Props> = ({ project }) => {
         newCommand = `${navigateCommand} && ${tmpCommand}`;
       }
 
+      record(originalCommand);
       runCommandAsync(newCommand);
       setCommand('');
+      resetPointer();
     }
   };
 
-  const handleKeyPress = (event: React.KeyboardEvent) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       handleSendCommand();
+      return;
+    }
+
+    if (isRunning) {
+      return;
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const previousCommand = getPrev(command);
+      setCommand(previousCommand);
+      moveCaretToEnd(previousCommand);
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const nextCommand = getNext(command);
+      setCommand(nextCommand);
+      moveCaretToEnd(nextCommand);
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setCommand('');
+      resetPointer();
+      moveCaretToEnd('');
     }
   };
 
@@ -193,8 +249,9 @@ export const Terminal: React.FC<Props> = ({ project }) => {
           placeholder="Type a rosetta or dbt command..."
           value={command}
           onChange={(e) => setCommand(e.target.value)}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyDown}
           disabled={isRunning}
+          inputRef={inputRef}
           sx={{
             '& .MuiInputBase-input': {
               color: terminalColors.fg,

--- a/src/renderer/hooks/index.ts
+++ b/src/renderer/hooks/index.ts
@@ -3,6 +3,7 @@ import useIpcPromise from './useIpcPromise';
 import useCli from './useCli';
 import useAppContext from './useAppContext';
 import useLocalStorage from './useLocalStorage';
+import useCommandHistory from './useCommandHistory';
 import useRosettaExtract from './useRosettaExtract';
 import useRosettaDBT from './useRosettaDBT';
 import useDbt from './useDbt';
@@ -16,6 +17,7 @@ export {
   useCli,
   useAppContext,
   useLocalStorage,
+  useCommandHistory,
   useRosettaExtract,
   useRosettaDBT,
   useDbt,

--- a/src/renderer/hooks/useCommandHistory.ts
+++ b/src/renderer/hooks/useCommandHistory.ts
@@ -1,0 +1,149 @@
+import React from 'react';
+import { toast } from 'react-toastify';
+
+const STORAGE_KEY = 'terminalHistory:global';
+const HISTORY_LIMIT = 100;
+
+const isBrowserEnvironment = () => typeof window !== 'undefined';
+
+const getSafeHistory = (): string[] => {
+  if (!isBrowserEnvironment()) {
+    return [];
+  }
+
+  try {
+    const storedValue = window.localStorage.getItem(STORAGE_KEY);
+    if (!storedValue) {
+      return [];
+    }
+
+    const parsed = JSON.parse(storedValue);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter((item): item is string => typeof item === 'string');
+  } catch (error) {
+    toast.error('Unable to load terminal command history.');
+    return [];
+  }
+};
+
+type UseCommandHistoryReturn = {
+  history: string[];
+  record: (command: string) => void;
+  getPrev: (currentInput: string) => string;
+  getNext: (currentInput: string) => string;
+  resetPointer: () => void;
+  clearHistory: () => void;
+};
+
+const useCommandHistory = (): UseCommandHistoryReturn => {
+  const [history, setHistory] = React.useState<string[]>(() =>
+    getSafeHistory(),
+  );
+  const [pointer, setPointer] = React.useState<number | null>(null);
+  const draftRef = React.useRef<string>('');
+  const saveErrorNotifiedRef = React.useRef<boolean>(false);
+
+  React.useEffect(() => {
+    if (!isBrowserEnvironment()) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+      saveErrorNotifiedRef.current = false;
+    } catch (error) {
+      if (!saveErrorNotifiedRef.current) {
+        toast.error('Unable to persist terminal command history.');
+        saveErrorNotifiedRef.current = true;
+      }
+    }
+  }, [history]);
+
+  const record = React.useCallback((command: string) => {
+    const trimmed = command.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    setHistory((prev) => {
+      if (prev[prev.length - 1] === trimmed) {
+        return prev;
+      }
+
+      const next = [...prev, trimmed];
+      if (next.length > HISTORY_LIMIT) {
+        return next.slice(next.length - HISTORY_LIMIT);
+      }
+
+      return next;
+    });
+
+    draftRef.current = '';
+    setPointer(null);
+  }, []);
+
+  const getPrev = React.useCallback(
+    (currentInput: string) => {
+      if (!history.length) {
+        return currentInput;
+      }
+
+      if (pointer === null) {
+        draftRef.current = currentInput;
+      }
+
+      const nextPointer =
+        pointer === null ? history.length - 1 : Math.max(pointer - 1, 0);
+      setPointer(nextPointer);
+      return history[nextPointer];
+    },
+    [history, pointer],
+  );
+
+  const getNext = React.useCallback(
+    (currentInput: string) => {
+      if (pointer === null) {
+        return currentInput;
+      }
+
+      const nextPointer = pointer + 1;
+      if (nextPointer >= history.length) {
+        setPointer(null);
+        const draft = draftRef.current;
+        draftRef.current = '';
+        return draft;
+      }
+
+      setPointer(nextPointer);
+      return history[nextPointer];
+    },
+    [history, pointer],
+  );
+
+  const resetPointer = React.useCallback(() => {
+    draftRef.current = '';
+    setPointer(null);
+  }, []);
+
+  const clearHistory = React.useCallback(() => {
+    setHistory([]);
+    resetPointer();
+  }, [resetPointer]);
+
+  return React.useMemo(
+    () => ({
+      history,
+      record,
+      getPrev,
+      getNext,
+      resetPointer,
+      clearHistory,
+    }),
+    [getNext, getPrev, history, record, resetPointer, clearHistory],
+  );
+};
+
+export default useCommandHistory;


### PR DESCRIPTION
- introduce useCommandHistory() to persist global history via `localStorage`
- wire history navigation and caret management into Terminal keyboard flow
- block bare `python` invocations to avoid frozen sessions while preserving script support