### PR TITLE
Fix/dbt commands double messages

### DIFF
--- a/src/renderer/components/dbtModelButtons/ModelSplitButton.tsx
+++ b/src/renderer/components/dbtModelButtons/ModelSplitButton.tsx
@@ -88,7 +88,6 @@ export const ModelSplitButton: React.FC<ModelSplitButtonProps> = ({
 
       setCompiledSql(realCompiledSql);
       setShowCompileModal(true);
-      toast.success('Model compiled successfully');
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
@@ -190,7 +189,6 @@ export const ModelSplitButton: React.FC<ModelSplitButtonProps> = ({
 
       setPreviewResult(modelPreviewResult);
       setShowPreviewModal(true);
-      toast.success('Model preview loaded successfully');
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';

--- a/src/renderer/hooks/useDbt.ts
+++ b/src/renderer/hooks/useDbt.ts
@@ -37,7 +37,10 @@ const ERROR_HINT_IGNORE_REGEX = /ERROR=0\b/i;
 const sanitizeCliLine = (line: string): string =>
   line.replace(ANSI_ESCAPE_REGEX, '').trimEnd();
 
-const extractCliErrorDetails = (output: string[], errors: string[]): string[] => {
+const extractCliErrorDetails = (
+  output: string[],
+  errors: string[],
+): string[] => {
   const details = new Set<string>();
 
   errors.forEach((err) => {
@@ -228,7 +231,10 @@ const useDbt = (successCallback?: () => void): UseDbtReturn => {
 
         // Execute command
         const result = await runCommand(cmdString);
-        const aggregatedError = extractCliErrorDetails(result.output, result.error);
+        const aggregatedError = extractCliErrorDetails(
+          result.output,
+          result.error,
+        );
 
         // Handle success vs failure
         if (aggregatedError.length === 0) {

--- a/src/renderer/hooks/useDbt.ts
+++ b/src/renderer/hooks/useDbt.ts
@@ -27,6 +27,54 @@ interface UseDbtReturn {
   activeCommand: DbtCommandType | null;
 }
 
+const ANSI_ESCAPE_REGEX = /\[[0-9;]*m/g;
+const ERROR_SUMMARY_REGEX = /ERROR=(\d+)/i;
+const NON_ZERO_EXIT_REGEX = /Process exited with code\s+(\d+)/i;
+const ERROR_HINT_REGEX =
+  /(Error importing adapter|Encountered an error|Runtime Error|Traceback|Database Error|Compilation Error|^ERROR:?\b|\bERROR\b)/i;
+const ERROR_HINT_IGNORE_REGEX = /ERROR=0\b/i;
+
+const sanitizeCliLine = (line: string): string =>
+  line.replace(ANSI_ESCAPE_REGEX, '').trimEnd();
+
+const extractCliErrorDetails = (output: string[], errors: string[]): string[] => {
+  const details = new Set<string>();
+
+  errors.forEach((err) => {
+    const sanitizedError = sanitizeCliLine(err);
+    if (sanitizedError) {
+      details.add(sanitizedError);
+    }
+  });
+
+  const cleanedOutput = output.map(sanitizeCliLine);
+
+  cleanedOutput.forEach((line) => {
+    const match = line.match(ERROR_SUMMARY_REGEX);
+    if (match && Number(match[1]) > 0) {
+      details.add(line);
+    }
+  });
+
+  cleanedOutput.forEach((line) => {
+    const match = line.match(NON_ZERO_EXIT_REGEX);
+    if (match && Number(match[1]) !== 0) {
+      details.add(line);
+    }
+  });
+
+  cleanedOutput.forEach((line) => {
+    if (ERROR_HINT_IGNORE_REGEX.test(line)) {
+      return;
+    }
+    if (ERROR_HINT_REGEX.test(line)) {
+      details.add(line);
+    }
+  });
+
+  return Array.from(details);
+};
+
 const useDbt = (successCallback?: () => void): UseDbtReturn => {
   const { data: settings } = useGetSettings();
   const { runCommand, stopCommand, isRunning } = useCli();
@@ -180,23 +228,7 @@ const useDbt = (successCallback?: () => void): UseDbtReturn => {
 
         // Execute command
         const result = await runCommand(cmdString);
-
-        // Helper: detect non-zero exit code forwarded in output and extract meaningful error
-        const hasNonZeroExit = result.output.some(
-          (line) =>
-            /Process exited with code\s+(\d+)/.test(line) &&
-            !/Process exited with code\s+0/.test(line),
-        );
-        const outputErrorHints = result.output.filter((line) =>
-          /(Error importing adapter|Encountered an error|Runtime Error|Traceback|\berror\b)/i.test(
-            line.replace(/\[[0-9;]*m/g, ''),
-          ),
-        );
-        const aggregatedError = [
-          ...result.error,
-          ...(hasNonZeroExit ? ['Process exited with non-zero code'] : []),
-          ...outputErrorHints,
-        ];
+        const aggregatedError = extractCliErrorDetails(result.output, result.error);
 
         // Handle success vs failure
         if (aggregatedError.length === 0) {
@@ -284,12 +316,11 @@ const useDbt = (successCallback?: () => void): UseDbtReturn => {
           const result = await runCommand(cmdString);
 
           // Detect failure via stderr forwarded to stdout or non-zero exit code indicator
-          const hasNonZeroExit = result.output.some(
-            (line) =>
-              /Process exited with code\s+(\d+)/.test(line) &&
-              !/Process exited with code\s+0/.test(line),
+          const aggregatedError = extractCliErrorDetails(
+            result.output,
+            result.error,
           );
-          if (result.error.length === 0 && !hasNonZeroExit) {
+          if (aggregatedError.length === 0) {
             // Extract the compiled SQL from the output
             let compiledSql = '';
 
@@ -341,15 +372,7 @@ const useDbt = (successCallback?: () => void): UseDbtReturn => {
 
             return finalResult;
           }
-          // Try to include helpful error hints from output
-          const outputErrorHints = result.output.filter((line) =>
-            /(Encountered an error|Runtime Error|Traceback|\berror\b)/i.test(
-              line.replace(/\[[0-9;]*m/g, ''),
-            ),
-          );
-          toast.info(
-            `dbt compile failed: ${[...result.error, ...outputErrorHints].join('\n')}`,
-          );
+          toast.info(`dbt compile failed: ${aggregatedError.join('\n')}`);
           return '';
         } catch (error) {
           const errorMessage =
@@ -394,22 +417,14 @@ const useDbt = (successCallback?: () => void): UseDbtReturn => {
           }
           const result = await runCommand(cmdString);
 
-          const hasNonZeroExit = result.output.some(
-            (line) =>
-              /Process exited with code\s+(\d+)/.test(line) &&
-              !/Process exited with code\s+0/.test(line),
+          const aggregatedError = extractCliErrorDetails(
+            result.output,
+            result.error,
           );
-          if (result.error.length === 0 && !hasNonZeroExit) {
+          if (aggregatedError.length === 0) {
             return result.output.join('\n');
           }
-          const outputErrorHints = result.output.filter((line) =>
-            /(Encountered an error|Runtime Error|Traceback|\berror\b)/i.test(
-              line.replace(/\[[0-9;]*m/g, ''),
-            ),
-          );
-          toast.info(
-            `dbt list failed: ${[...result.error, ...outputErrorHints].join('\n')}`,
-          );
+          toast.info(`dbt list failed: ${aggregatedError.join('\n')}`);
           return '';
         } catch (error) {
           const errorMessage =

--- a/src/renderer/hooks/useRosettaDBT.ts
+++ b/src/renderer/hooks/useRosettaDBT.ts
@@ -26,24 +26,46 @@ const useRosettaDBT = (successCallback: () => Promise<void>) => {
   const { data: connections = [] } = useGetConnections();
 
   React.useEffect(() => {
-    if (!isRunning) return;
+    let isCancelled = false;
+
+    const resetState = () => {
+      setIsRunning(false);
+      setIsSuccess(false);
+    };
+
+    if (!isRunning) {
+      return () => {
+        isCancelled = true;
+      };
+    }
+
     if (error.length > 0) {
       toast.error('Rosetta dbt command failed');
-      setIsRunning(false);
-      return;
+      resetState();
+      return () => {
+        isCancelled = true;
+      };
     }
-    const handleSuccess = async () => {
-      await successCallback();
-      toast.success('Rosetta dbt completed successfully');
-      setIsRunning(false);
-    };
+
     if (isSuccess) {
+      const handleSuccess = async () => {
+        await successCallback();
+        if (!isCancelled) {
+          toast.success('Rosetta dbt completed successfully');
+          resetState();
+        }
+      };
       handleSuccess();
     }
-  }, [isSuccess, error]);
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [isSuccess, error, isRunning, successCallback]);
 
   return {
     fn: async (project: Project, command: Command) => {
+      setIsSuccess(false);
       setIsRunning(true);
       const connection = connections.find((c) => c.id === project.connectionId);
       if (!connection) {


### PR DESCRIPTION
This pull request refactors error detection and notification logic for dbt command execution and model actions, aiming to provide more accurate and helpful error reporting. The main changes include consolidating CLI error extraction into a single utility, updating toast notifications to avoid misleading success messages, and improving state management in Rosetta dbt operations.

**Error detection and reporting improvements:**

* Added a new utility function (`extractCliErrorDetails`) in `useDbt.ts` to centralize and enhance the extraction of error details from CLI output, replacing scattered regex checks and manual error hint aggregation.
* Updated dbt command execution logic in `useDbt.ts` to use the new error extraction utility for all commands, ensuring consistent error detection and reporting via toast notifications.

**User notification changes:**

* Removed success toast notifications from `ModelSplitButton.tsx` for model compile and preview actions.

**Rosetta dbt state management:**

* Refactored `useRosettaDBT.ts` to improve state reset and cancellation handling, ensuring that toast notifications and state updates occur correctly even if the component unmounts or the operation is interrupted.