### PR TITLE
fix(database): correct migration index creation order

### DIFF
--- a/src/main/services/mainDatabase.service.ts
+++ b/src/main/services/mainDatabase.service.ts
@@ -236,16 +236,8 @@ export default class MainDatabaseService {
       CREATE INDEX IF NOT EXISTS ai_providers_type_idx ON ai_providers(type);
       CREATE INDEX IF NOT EXISTS ai_providers_active_idx ON ai_providers(is_active);
 
-      CREATE INDEX IF NOT EXISTS chat_conversations_project_idx ON chat_conversations(project_id);
-      CREATE INDEX IF NOT EXISTS chat_conversations_screen_key_idx ON chat_conversations(screen_key);
-      CREATE INDEX IF NOT EXISTS chat_conversations_connection_idx ON chat_conversations(connection_id);
-      CREATE INDEX IF NOT EXISTS chat_conversations_provider_idx ON chat_conversations(provider_id);
-      CREATE INDEX IF NOT EXISTS chat_conversations_created_at_idx ON chat_conversations(created_at);
-
       CREATE INDEX IF NOT EXISTS chat_messages_conversation_idx ON chat_messages(conversation_id);
       CREATE INDEX IF NOT EXISTS chat_messages_role_idx ON chat_messages(role);
-      CREATE INDEX IF NOT EXISTS chat_messages_parent_idx ON chat_messages(parent_message_id);
-      CREATE INDEX IF NOT EXISTS chat_messages_streaming_idx ON chat_messages(is_streaming);
       CREATE INDEX IF NOT EXISTS chat_messages_created_at_idx ON chat_messages(created_at);
 
       CREATE INDEX IF NOT EXISTS context_items_message_idx ON context_items(message_id);
@@ -295,22 +287,48 @@ export default class MainDatabaseService {
 
       // chat_conversations: ensure enhanced columns exist
       const chatConvCols = getColumns('chat_conversations');
+
+      if (!chatConvCols.has('project_id')) {
+        alterStatements.push(
+          'ALTER TABLE chat_conversations ADD COLUMN project_id INTEGER;',
+        );
+      }
+
+      if (!chatConvCols.has('provider_id')) {
+        alterStatements.push(
+          'ALTER TABLE chat_conversations ADD COLUMN provider_id INTEGER;',
+        );
+      }
+
       if (!chatConvCols.has('screen_key')) {
         alterStatements.push(
           "ALTER TABLE chat_conversations ADD COLUMN screen_key TEXT DEFAULT 'project';",
         );
-        alterStatements.push(
-          'CREATE INDEX IF NOT EXISTS chat_conversations_screen_key_idx ON chat_conversations(screen_key);',
-        );
       }
+
       if (!chatConvCols.has('connection_id')) {
         alterStatements.push(
           'ALTER TABLE chat_conversations ADD COLUMN connection_id TEXT;',
         );
-        alterStatements.push(
-          'CREATE INDEX IF NOT EXISTS chat_conversations_connection_idx ON chat_conversations(connection_id);',
-        );
       }
+
+      // Ensure indexes exist for chat_conversations (safe with CREATE INDEX IF NOT EXISTS if columns exist)
+      // We run these after potentially adding columns above
+      alterStatements.push(
+        'CREATE INDEX IF NOT EXISTS chat_conversations_project_idx ON chat_conversations(project_id);',
+      );
+      alterStatements.push(
+        'CREATE INDEX IF NOT EXISTS chat_conversations_screen_key_idx ON chat_conversations(screen_key);',
+      );
+      alterStatements.push(
+        'CREATE INDEX IF NOT EXISTS chat_conversations_connection_idx ON chat_conversations(connection_id);',
+      );
+      alterStatements.push(
+        'CREATE INDEX IF NOT EXISTS chat_conversations_provider_idx ON chat_conversations(provider_id);',
+      );
+      alterStatements.push(
+        'CREATE INDEX IF NOT EXISTS chat_conversations_created_at_idx ON chat_conversations(created_at);',
+      );
 
       // chat_messages: ensure enhanced columns exist
       const chatMsgCols = getColumns('chat_messages');
@@ -344,6 +362,14 @@ export default class MainDatabaseService {
           'ALTER TABLE chat_messages ADD COLUMN parent_message_id INTEGER;',
         );
       }
+
+      // Ensure indexes exist for chat_messages (safe if columns exist)
+      alterStatements.push(
+        'CREATE INDEX IF NOT EXISTS chat_messages_parent_idx ON chat_messages(parent_message_id);',
+      );
+      alterStatements.push(
+        'CREATE INDEX IF NOT EXISTS chat_messages_streaming_idx ON chat_messages(is_streaming);',
+      );
 
       if (alterStatements.length > 0) {
         const transaction = this.sqlite.transaction((sqls: string[]) => {


### PR DESCRIPTION
restructure chat_conversations and chat_messages table migrations to first add all missing columns, then create required indexes. this prevents sqlite errors from attempting to create indexes on non-existent columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized database index creation for improved schema structure.
  * Enhanced database upgrade mechanism to more reliably detect and add missing schema components to existing installations.
  * Improved indexing across chat-related database operations to ensure consistent schema across all database versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rosettadb/dbt-studio/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->