### PR TITLE
Feature/notebooks ai agent

### DIFF
--- a/src/main/ipcHandlers/agent.ipcHandlers.ts
+++ b/src/main/ipcHandlers/agent.ipcHandlers.ts
@@ -46,6 +46,34 @@ export const registerAgentHandlers = () => {
     ) => AgentService.resolveEditorUpdateResponse(payload),
   );
 
+  ipcMain.handle('agent:notebook:state-response', async (_event, payload) =>
+    AgentService.resolveNotebookBridgeResponse(payload),
+  );
+
+  ipcMain.handle('agent:notebook:cell-read-response', async (_event, payload) =>
+    AgentService.resolveNotebookBridgeResponse(payload),
+  );
+
+  ipcMain.handle('agent:notebook:cell-add-response', async (_event, payload) =>
+    AgentService.resolveNotebookBridgeResponse(payload),
+  );
+
+  ipcMain.handle(
+    'agent:notebook:cell-update-response',
+    async (_event, payload) =>
+      AgentService.resolveNotebookBridgeResponse(payload),
+  );
+
+  ipcMain.handle('agent:notebook:cell-run-response', async (_event, payload) =>
+    AgentService.resolveNotebookBridgeResponse(payload),
+  );
+
+  ipcMain.handle(
+    'agent:notebook:cell-result-response',
+    async (_event, payload) =>
+      AgentService.resolveNotebookBridgeResponse(payload),
+  );
+
   // Thin wrapper — all logic in AgentEditorBridgeService (BE-01)
   ipcMain.handle(
     'agent:editor:get-query-results',

--- a/src/main/ipcHandlers/ai.ipcHandlers.ts
+++ b/src/main/ipcHandlers/ai.ipcHandlers.ts
@@ -167,6 +167,7 @@ const registerAIHandlers = () => {
         projectId?: number;
         screenKey?: any;
         connectionId?: string | null;
+        notebookId?: string | null;
       },
     ): Promise<ChatConversation[]> => {
       return MainDatabaseService.getConversations(filter ?? {});
@@ -187,12 +188,14 @@ const registerAIHandlers = () => {
         providerId,
         screenKey,
         connectionId,
+        notebookId,
       }: {
         title: string;
         projectId?: number;
         providerId?: number;
         screenKey?: any;
         connectionId?: string;
+        notebookId?: string;
       },
     ): Promise<ChatConversation> => {
       return MainDatabaseService.createConversation(
@@ -201,6 +204,7 @@ const registerAIHandlers = () => {
         providerId,
         screenKey,
         connectionId,
+        notebookId,
       );
     },
   );

--- a/src/main/schemas/mainDatabase.schema.ts
+++ b/src/main/schemas/mainDatabase.schema.ts
@@ -39,6 +39,7 @@ export const chatConversations = sqliteTable(
     projectId: integer('project_id'), // References existing project IDs from database.json (read-only)
     screenKey: text('screen_key').default('project').notNull(),
     connectionId: text('connection_id'),
+    notebookId: text('notebook_id'),
     providerId: integer('provider_id').references(() => aiProviders.id, {
       onDelete: 'set null',
     }),

--- a/src/main/services/agent.service.ts
+++ b/src/main/services/agent.service.ts
@@ -112,6 +112,16 @@ const pendingEditorBridgeRequests = new Map<
   }
 >();
 
+const pendingNotebookBridgeRequests = new Map<
+  string,
+  {
+    resolve: (value: any) => void;
+    reject: (reason?: unknown) => void;
+    timeout: ReturnType<typeof setTimeout>;
+    type: string;
+  }
+>();
+
 // Per-conversation agent context — replaces the static singleton to prevent
 // race conditions when multiple conversations run concurrently (#4)
 const agentContexts = new Map<
@@ -121,6 +131,7 @@ const agentContexts = new Map<
     conversationId: number;
     screenKey: 'project' | 'sql' | 'notebooks';
     connectionId?: string;
+    notebookId?: string;
     projectPath?: string;
   }
 >();
@@ -174,9 +185,9 @@ export interface AgentRunRequest {
   requestedModel?: string;
   projectPath?: string;
   toolMode?: 'chat' | 'agent';
-  screenKey?: 'project' | 'sql' | 'notebooks';
+  screenKey?: import('../../types/agentEvents').AgentScreenKey;
   connectionId?: string;
-  notebookId?: number;
+  notebookId?: string;
 }
 
 /**
@@ -363,6 +374,144 @@ class AgentService {
       conversationId,
       query,
     });
+  }
+
+  // ─── Notebook Agent Bridge (Phase 1) ──────────────────────────────────────────
+
+  private static async requestNotebookBridge(
+    conversationId: number,
+    type: string,
+    requestChannel: string,
+    responseChannel: string,
+    payload: object = {},
+  ): Promise<any> {
+    const context = this.getAgentContext(conversationId);
+    if (!context) {
+      throw new Error(`No active context for conversation ${conversationId}`);
+    }
+
+    const requestId = `notebook-bridge-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 10)}`;
+
+    return new Promise<any>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingNotebookBridgeRequests.delete(requestId);
+        reject(
+          new Error(`Timed out waiting for ${type} response from renderer`),
+        );
+      }, 15000);
+
+      pendingNotebookBridgeRequests.set(requestId, {
+        resolve,
+        reject,
+        timeout,
+        type,
+      });
+
+      context.event.sender.send(requestChannel, {
+        requestId,
+        conversationId,
+        ...payload,
+      });
+    });
+  }
+
+  public static resolveNotebookBridgeResponse(payload: {
+    requestId: string;
+    success: boolean;
+    [key: string]: any;
+  }): void {
+    const request = pendingNotebookBridgeRequests.get(payload.requestId);
+    if (!request) return;
+
+    pendingNotebookBridgeRequests.delete(payload.requestId);
+    clearTimeout(request.timeout);
+
+    if (payload.success) {
+      request.resolve(payload);
+    } else {
+      request.reject(new Error(payload.error || 'Renderer request failed'));
+    }
+  }
+
+  public static async requestNotebookState(conversationId: number) {
+    return this.requestNotebookBridge(
+      conversationId,
+      'state',
+      'agent:notebook:state-request',
+      'agent:notebook:state-response',
+    );
+  }
+
+  public static async requestNotebookCellRead(
+    conversationId: number,
+    cellId: string,
+  ) {
+    return this.requestNotebookBridge(
+      conversationId,
+      'cell-read',
+      'agent:notebook:cell-read-request',
+      'agent:notebook:cell-read-response',
+      { cellId },
+    );
+  }
+
+  public static async requestNotebookCellAdd(
+    conversationId: number,
+    content: string,
+  ): Promise<{ cellId: string }> {
+    return this.requestNotebookBridge(
+      conversationId,
+      `cell-add-${Date.now()}`,
+      'agent:notebook:cell-add-request',
+      'agent:notebook:cell-add-response',
+      { content },
+    );
+  }
+
+  public static async requestNotebookCellUpdate(
+    conversationId: number,
+    cellId: string,
+    content: string,
+  ) {
+    return this.requestNotebookBridge(
+      conversationId,
+      'cell-update',
+      'agent:notebook:cell-update-request',
+      'agent:notebook:cell-update-response',
+      { cellId, content },
+    );
+  }
+
+  public static async requestNotebookCellRun(
+    conversationId: number,
+    cellId: string,
+  ) {
+    const context = this.getAgentContext(conversationId);
+    if (!context) {
+      throw new Error(`No active context for conversation ${conversationId}`);
+    }
+    return this.requestNotebookBridge(
+      conversationId,
+      `cell-run-${cellId}`,
+      'agent:notebook:cell-run-request',
+      'agent:notebook:cell-run-response',
+      { cellId },
+    );
+  }
+
+  public static async requestNotebookCellResult(
+    conversationId: number,
+    cellId: string,
+  ) {
+    return this.requestNotebookBridge(
+      conversationId,
+      'cell-result',
+      'agent:notebook:cell-result-request',
+      'agent:notebook:cell-result-response',
+      { cellId },
+    );
   }
 
   // ─── Context Compaction ──────────────────────────────────────────────────────
@@ -614,6 +763,7 @@ SUMMARY:`,
         conversationId,
         screenKey: request.screenKey ?? 'project',
         connectionId: request.connectionId,
+        notebookId: request.notebookId,
         projectPath,
       });
 
@@ -737,6 +887,7 @@ SUMMARY:`,
           agent = await createNotebooksAgent(base, {
             connectionMeta,
             notebookId: request.notebookId,
+            connectionId: request.connectionId,
             projectPath,
             enabledTools,
             skills: base.skillsPrompt,

--- a/src/main/services/ai/agents/notebooksAgent.ts
+++ b/src/main/services/ai/agents/notebooksAgent.ts
@@ -4,10 +4,15 @@ import type { BaseAgentConfig } from './baseAgentConfig';
 import { createStudioCloudTools } from '../tools/studio/cloud.tools';
 import { createStudioConnectionsTools } from '../tools/studio/connections.tools';
 import { createStudioDuckLakeTools } from '../tools/studio/ducklake.tools';
+import { createStudioNotebooksTools } from '../tools/studio/notebooks.tools';
+import { NotebooksService } from '../../notebooks.service';
+import { TOOL_FLAGS } from '../tools/toolRegistry';
+import type { NotebookCell } from '../../../../types/notebooks';
 
 export interface NotebooksAgentOptions {
   connectionMeta: { name: string; type: string };
-  notebookId?: number;
+  notebookId?: string;
+  connectionId?: string;
   projectPath?: string;
   enabledTools: Record<string, any>;
   skills: string;
@@ -15,19 +20,131 @@ export interface NotebooksAgentOptions {
   toolMode: 'chat' | 'agent';
 }
 
+async function buildNotebookContextSummary(
+  connectionId: string,
+  notebookId: string,
+): Promise<string> {
+  try {
+    const notebook = await NotebooksService.getNotebook(
+      connectionId,
+      notebookId,
+    );
+    if (!notebook) return '';
+
+    let summary = `\n## Active Notebook: ${notebook.name}\n`;
+    if (notebook.description) {
+      summary += `Description: ${notebook.description}\n`;
+    }
+    summary += `Total Cells: ${notebook.cells.length}\n\n`;
+
+    notebook.cells.forEach((cell: NotebookCell, index: number) => {
+      const preview = cell.content.split('\n')[0].substring(0, 80);
+      summary += `[Cell ${index + 1}] ID: ${cell.id} | Type: ${cell.type}\n`;
+      summary += `Preview: ${preview}${cell.content.length > 80 ? '...' : ''}\n`;
+      if (cell.output) {
+        summary += `Status: ${cell.output.type}${cell.output.executionTime ? ` (${cell.output.executionTime}ms)` : ''}\n`;
+      }
+      summary += '\n';
+    });
+
+    return summary;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('[NotebooksAgent] Failed to build notebook summary:', error);
+    return '\n## Active Notebook\n(Metadata summary unavailable)\n';
+  }
+}
+
 export async function createNotebooksAgent(
   base: BaseAgentConfig,
   options: NotebooksAgentOptions,
 ) {
-  const { connectionMeta, notebookId, projectPath, enabledTools, skills } =
-    options;
+  const {
+    connectionMeta,
+    notebookId,
+    connectionId,
+    projectPath,
+    enabledTools,
+    skills,
+  } = options;
   const mcpToolKeys = Object.keys(base.mcpTools || {});
   const mcpToolsList =
     mcpToolKeys.length > 0
       ? `\n\n## MCP Server Tools\nConnected MCP servers have exposed these external tools:\n${mcpToolKeys.map((k) => `- ${k}`).join('\n')}\nUse these tools when the user asks about MCP-backed documentation, repository/source-code reference, or external MCP capabilities.`
       : '';
 
+  // DuckLake is a DuckDB extension (not a JS package), version is fixed
+  let duckdbVersion = '1.5.2+';
+  const ducklakeVersion = '1.0';
+
+  try {
+    // Dynamically resolve duckdb version the exact same way the footer does
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    const ddbPkg = require('@duckdb/node-api/package.json');
+    if (ddbPkg && ddbPkg.version) {
+      duckdbVersion = ddbPkg.version;
+    }
+  } catch (e) {
+    // fallback
+  }
+
+  let connectionHints = '';
+  switch (connectionMeta.type) {
+    case 'ducklake':
+      connectionHints = `\n\n## DuckLake Specifics
+You are connected to a DuckLake lakehouse. DuckLake is a DuckDB extension (not a separate library).
+- Versions: DuckDB v${duckdbVersion}, DuckLake extension minimal v${ducklakeVersion}.
+- Dialect: Use DuckDB SQL dialect and functions.
+- Attach: \`ATTACH 'ducklake:my.ducklake' AS my_ducklake; USE my_ducklake;\`
+- Time Travel: \`SELECT ... FROM tbl AT (VERSION => 2)\` or \`AT (TIMESTAMP => '2025-01-01')\`
+- Snapshots: \`FROM my_ducklake.snapshots();\`
+- Constraints: No indexes, primary keys, foreign keys, UNIQUE or CHECK constraints.
+- Updates: Modeled as deletes followed by inserts (append-only Parquet storage).
+- Detach: \`USE memory; DETACH my_ducklake;\``;
+      break;
+    case 'duckdb':
+      connectionHints =
+        '\n\n## Dialect Specifics\nYou are connected to DuckDB. Ensure all queries use DuckDB SQL syntax and functions.';
+      break;
+    case 'postgres':
+    case 'postgresql':
+      connectionHints =
+        '\n\n## Dialect Specifics\nYou are connected to PostgreSQL. Ensure all queries use PostgreSQL SQL syntax and functions.';
+      break;
+    case 'bigquery':
+      connectionHints =
+        '\n\n## Dialect Specifics\nYou are connected to Google BigQuery. Ensure all queries use BigQuery Standard SQL syntax.';
+      break;
+    case 'snowflake':
+      connectionHints =
+        '\n\n## Dialect Specifics\nYou are connected to Snowflake. Ensure all queries use Snowflake SQL syntax and functions.';
+      break;
+    case 'redshift':
+      connectionHints =
+        '\n\n## Dialect Specifics\nYou are connected to Amazon Redshift. Ensure all queries use Redshift SQL syntax and functions.';
+      break;
+    case 'databricks':
+      connectionHints =
+        '\n\n## Dialect Specifics\nYou are connected to Databricks. Ensure all queries use Databricks/Spark SQL syntax and functions.';
+      break;
+    case 'kinetica':
+      connectionHints =
+        '\n\n## Dialect Specifics\nYou are connected to Kinetica. Ensure all queries use Kinetica SQL syntax and functions.';
+      break;
+    default:
+      connectionHints = `\n\n## Dialect Specifics\nYou are connected to a ${connectionMeta.type} database. Ensure all queries use the correct dialect for this database.`;
+      break;
+  }
+
   const isAskMode = options.toolMode === 'chat';
+
+  let notebookSummary = '';
+  if (connectionId && notebookId) {
+    notebookSummary = await buildNotebookContextSummary(
+      connectionId,
+      notebookId,
+    );
+  }
 
   const systemInstructions = isAskMode
     ? `You are an expert AI assistant for data notebooks. You are running in **Ask (read-only) mode**.
@@ -35,8 +152,8 @@ export async function createNotebooksAgent(
 ## Active Connection
 
 Name: ${connectionMeta.name}
-Type: ${connectionMeta.type}
-${notebookId ? `\n## Active Notebook\n\nNotebook ID: ${notebookId}\n` : ''}
+Type: ${connectionMeta.type}${connectionHints}
+${notebookId ? `\n## Active Notebook\n\nNotebook ID: ${notebookId}\n` : ''}${notebookSummary}
 ## Ask Mode Constraints
 
 You are in **Ask mode**. You can only read and analyze — you CANNOT execute queries, create tables, or modify data.
@@ -45,12 +162,39 @@ If the user asks you to perform a write operation, explain what it would look li
 ${skills ?? ''}
 ${mcpToolsList}`
     : `You are an expert data engineering assistant in the Notebooks screen.
+Your goal is to help the user perform complex, multi-step data analysis and engineering workflows autonomously.
+
+## Capabilities & Workflow
+1. **Analyze Schema**: Use DuckLake tools to understand the database structure (tables, columns).
+2. **Notebook Awareness**: Use \`notebooks_get_state\` to see which cells exist.
+3. **Strict Single-Statement Cells**:
+   - **CRITICAL RULE**: You can only write ONE SQL statement per cell. Multiple SQL statements (statement chaining) are strictly forbidden and will fail.
+   - If you have a complex task requiring multiple steps, you MUST generate multiple cells in sequence:
+     1. Use \`notebooks_cell_add\` to create a new cell.
+     2. Write ONE query in the new cell.
+     3. Execute the cell with \`notebooks_cell_run\`.
+     4. Read the result with \`notebooks_cell_result\`.
+     5. Based on the response, if you need to continue, create another new cell with \`notebooks_cell_add\` and repeat.
+4. **Iterative Authoring & Verification**:
+   - After running a cell, wait a moment and then use \`notebooks_cell_result\` to inspect the output.
+   - If the output contains errors, update the broken cell with \`notebooks_cell_update\` and re-run.
+   - Do NOT stop until the task is complete or you hit a blocker you cannot resolve.
+
+## Pagination & Large Datasets
+The notebook UI handles large datasets efficiently using server-side pagination.
+- **Do not use explicit LIMIT clauses** in your queries.
+- Any explicit \`LIMIT\` or \`OFFSET\` clauses you write will be **stripped and ignored** by the execution engine to prevent pagination conflicts.
+- When you read results, you will only receive the first page (up to 10 rows). Use this to verify logic.
+- The UI handles fetching the rest of the dataset automatically, so you don't need to worry about large datasets crashing the system.
+
+## Behavioral Rules
+- **No Suggestions**: Your users are Data Engineers who already have specific tasks defined by stakeholders. Do NOT suggest what to do next. Do NOT ask "Would you like me to...?" or "What would you like to do next?".
+- **Concise Reporting**: Just explain or answer exactly what you have done. Be brief and professional. Do NOT add conversational filler.
 
 ## Active Connection
-
 Name: ${connectionMeta.name}
-Type: ${connectionMeta.type}
-${notebookId ? `\n## Active Notebook\n\nNotebook ID: ${notebookId}\n` : ''}
+Type: ${connectionMeta.type}${connectionHints}
+${notebookId ? `\n## Active Notebook\n\nNotebook ID: ${notebookId}\n` : ''}${notebookSummary}
 ${
   projectPath
     ? `## Active dbt Project\n\nProject path: ${projectPath}\n`
@@ -59,10 +203,17 @@ ${
 ${skills ?? ''}
 ${mcpToolsList}`;
 
+  const safeEnabledTools = { ...enabledTools };
+  // The Notebooks screen does not have the SQL Editor bridge, so studio_ducklake_query
+  // (which writes to the Monaco SQL editor) will crash/hang. Remove it.
+  delete safeEnabledTools.studio_ducklake_query;
+  delete safeEnabledTools.studio_sql_query;
+
   const studioNotebookTools: Record<string, any> = {
     ...createStudioConnectionsTools(),
     ...createStudioCloudTools(),
     ...createStudioDuckLakeTools(options.conversationId),
+    ...createStudioNotebooksTools(options.conversationId),
   };
 
   const READ_ONLY_TOOLS = [
@@ -70,6 +221,9 @@ ${mcpToolsList}`;
     'studio_connections_list',
     'studio_cloud_list_objects',
     'studio_cloud_preview_data',
+    'notebooks_get_state',
+    'notebooks_cell_read',
+    'notebooks_cell_result',
   ];
 
   const makeAskModeStub = (toolName: string): any => {
@@ -84,7 +238,11 @@ ${mcpToolsList}`;
 
   const baseTools: Record<string, any> = {};
   Object.entries(studioNotebookTools).forEach(([name, toolDef]) => {
-    if (enabledTools?.[name] !== false) {
+    const isEnabledInRegistry =
+      (TOOL_FLAGS as Record<string, boolean>)[name] !== false;
+    const isEnabledInMode = safeEnabledTools?.[name] !== false;
+
+    if (isEnabledInRegistry && isEnabledInMode) {
       if (isAskMode && !READ_ONLY_TOOLS.includes(name)) {
         baseTools[name] = makeAskModeStub(name);
       } else {

--- a/src/main/services/ai/agents/sqlAgent.ts
+++ b/src/main/services/ai/agents/sqlAgent.ts
@@ -172,7 +172,9 @@ ${mcpToolsList}
 3. Call \`studio_sql_get_agent_run_result\` after every single \`studio_sql_query\` call.
 4. Only use \`studio_monaco_update\` to correct a broken SQL statement — not for normal query submission.
 5. Prefer read-only operations unless the user explicitly requests writes.
-6. For DML/DDL operations, proceed directly — the execution tool has a built-in approval gate that will automatically request user confirmation before running. Do NOT ask for approval in the chat.`;
+6. For DML/DDL operations, proceed directly — the execution tool has a built-in approval gate that will automatically request user confirmation before running. Do NOT ask for approval in the chat.
+7. **No Suggestions**: Your users are Data Engineers. Do NOT suggest what to do next. Do NOT ask "Would you like me to...?". Just explain what you have done.
+8. **Concise Reporting**: Be brief and professional. Do NOT add conversational filler.`;
 
   // SQL connection tools + Monaco editor tools
   const isDuckLake = connectionMeta.type === 'ducklake';

--- a/src/main/services/ai/tools/studio/notebooks.tools.ts
+++ b/src/main/services/ai/tools/studio/notebooks.tools.ts
@@ -1,0 +1,226 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import AgentService from '../../../agent.service';
+import { truncateToolResult } from '../../tokenEstimator';
+import { TerminalConfirmGate } from '../terminalConfirmGate';
+import { isMutationSql } from './sql.tools';
+
+const DEFAULT_MAX_OUTPUT_TOKENS = 4000;
+
+export function createStudioNotebooksTools(conversationId: number) {
+  return {
+    notebooks_get_state: tool({
+      description:
+        'Get the current state of the notebook, including all cell IDs and types.',
+      inputSchema: z.object({}),
+      execute: async () => {
+        const startedAt = Date.now();
+        try {
+          const response =
+            await AgentService.requestNotebookState(conversationId);
+          // Strip internal IPC wrapper fields from the LLM's view
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { requestId, success, ...cleanState } = response as any;
+          return {
+            ok: true,
+            data: cleanState,
+            meta: { duration: Date.now() - startedAt },
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : 'Failed to get notebook state',
+            meta: { duration: Date.now() - startedAt },
+          };
+        }
+      },
+    }),
+
+    notebooks_cell_read: tool({
+      description: 'Read the content of a specific notebook cell.',
+      inputSchema: z.object({
+        cellId: z.string().describe('The ID of the cell to read'),
+      }),
+      execute: async ({ cellId }) => {
+        const startedAt = Date.now();
+        try {
+          const response = await AgentService.requestNotebookCellRead(
+            conversationId,
+            cellId,
+          );
+          const content = response.content ?? '';
+          return {
+            ok: true,
+            data: { content, length: content.length },
+            output: truncateToolResult(content, DEFAULT_MAX_OUTPUT_TOKENS),
+            meta: { duration: Date.now() - startedAt },
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            error:
+              error instanceof Error ? error.message : 'Failed to read cell',
+            meta: { duration: Date.now() - startedAt },
+          };
+        }
+      },
+    }),
+
+    notebooks_cell_add: tool({
+      description:
+        'Create a new SQL cell at the end of the notebook with the given content.',
+      inputSchema: z.object({
+        content: z.string().describe('The SQL content for the new cell'),
+      }),
+      execute: async ({ content }) => {
+        const startedAt = Date.now();
+        try {
+          const { cellId } = await AgentService.requestNotebookCellAdd(
+            conversationId,
+            content,
+          );
+          return {
+            ok: true,
+            data: { cellId },
+            meta: { duration: Date.now() - startedAt },
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            error:
+              error instanceof Error ? error.message : 'Failed to add cell',
+            meta: { duration: Date.now() - startedAt },
+          };
+        }
+      },
+    }),
+
+    notebooks_cell_update: tool({
+      description: 'Update the content of a specific notebook cell.',
+      inputSchema: z.object({
+        cellId: z.string().describe('The ID of the cell to update'),
+        content: z.string().describe('The new content for the cell'),
+      }),
+      execute: async ({ cellId, content }) => {
+        const startedAt = Date.now();
+        try {
+          const response = await AgentService.requestNotebookCellUpdate(
+            conversationId,
+            cellId,
+            content,
+          );
+          return {
+            ok: true,
+            data: { applied: response.applied },
+            meta: { duration: Date.now() - startedAt },
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            error:
+              error instanceof Error ? error.message : 'Failed to update cell',
+            meta: { duration: Date.now() - startedAt },
+          };
+        }
+      },
+    }),
+
+    notebooks_cell_run: tool({
+      description:
+        'Run/Execute a specific notebook cell. This triggers execution in the frontend.',
+      inputSchema: z.object({
+        cellId: z.string().describe('The ID of the cell to run'),
+      }),
+      execute: async ({ cellId }) => {
+        const startedAt = Date.now();
+        try {
+          const context = AgentService.getAgentContext(conversationId);
+          if (!context) {
+            return {
+              ok: false,
+              error: 'No active connection found',
+              meta: { duration: Date.now() - startedAt },
+            };
+          }
+
+          // Step 1: Read the cell content to check if it's a mutation
+          const readRes = await AgentService.requestNotebookCellRead(
+            conversationId,
+            cellId,
+          );
+
+          if (readRes.content && isMutationSql(readRes.content)) {
+            const allowed = await TerminalConfirmGate.request({
+              event: context.event,
+              conversationId,
+              toolName: 'notebooks_cell_run',
+              command: `⚠️ This is a DML/DDL operation that will modify your database.\n\n${readRes.content}`,
+              cwd: `connection:${context.connectionId}`,
+            });
+
+            if (!allowed) {
+              return {
+                ok: false,
+                error: 'Query denied by user',
+                meta: {
+                  duration: Date.now() - startedAt,
+                  requiresApproval: true,
+                },
+              };
+            }
+          }
+
+          await AgentService.requestNotebookCellRun(conversationId, cellId);
+          return {
+            ok: true,
+            data: { status: 'triggered' },
+            meta: { duration: Date.now() - startedAt },
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            error:
+              error instanceof Error ? error.message : 'Failed to run cell',
+            meta: { duration: Date.now() - startedAt },
+          };
+        }
+      },
+    }),
+
+    notebooks_cell_result: tool({
+      description: 'Get the last execution result of a specific notebook cell.',
+      inputSchema: z.object({
+        cellId: z.string().describe('The ID of the cell to get results for'),
+      }),
+      execute: async ({ cellId }) => {
+        const startedAt = Date.now();
+        try {
+          const response = await AgentService.requestNotebookCellResult(
+            conversationId,
+            cellId,
+          );
+          const { result } = response;
+          const raw = JSON.stringify(result);
+          return {
+            ok: true,
+            data: result,
+            output: truncateToolResult(raw, DEFAULT_MAX_OUTPUT_TOKENS),
+            meta: { duration: Date.now() - startedAt },
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            error:
+              error instanceof Error
+                ? error.message
+                : 'Failed to get cell result',
+            meta: { duration: Date.now() - startedAt },
+          };
+        }
+      },
+    }),
+  };
+}

--- a/src/main/services/ai/tools/studio/sql.tools.ts
+++ b/src/main/services/ai/tools/studio/sql.tools.ts
@@ -40,7 +40,7 @@ function filterSchemaTables(tables: any[], tableFilter?: string): any[] {
   });
 }
 
-function getFirstSqlVerb(sql: string): string {
+export function getFirstSqlVerb(sql: string): string {
   // 1. Strip comments
   const withoutComments = sql
     .replace(/\/\*[\s\S]*?\*\//g, ' ')
@@ -100,7 +100,7 @@ function getFirstSqlVerb(sql: string): string {
   return match?.[1]?.toUpperCase() ?? '';
 }
 
-function isMutationSql(sql: string): boolean {
+export function isMutationSql(sql: string): boolean {
   const verb = getFirstSqlVerb(sql);
   return [
     'INSERT',

--- a/src/main/services/ai/tools/toolRegistry.ts
+++ b/src/main/services/ai/tools/toolRegistry.ts
@@ -14,6 +14,12 @@ export const TOOL_FLAGS: Record<string, boolean> = {
   'studio.cloud.preview_data': true,
   'studio.cloud.connection_test': true,
   'studio.cli.run_dbt': true,
+  notebooks_get_state: true,
+  notebooks_cell_read: true,
+  notebooks_cell_add: true,
+  notebooks_cell_update: true,
+  notebooks_cell_run: true,
+  notebooks_cell_result: true,
 };
 
 export function isToolEnabled(flag: string): boolean {

--- a/src/main/services/mainDatabase.service.ts
+++ b/src/main/services/mainDatabase.service.ts
@@ -34,6 +34,7 @@ export interface GetConversationsFilter {
   projectId?: number;
   screenKey?: AgentScreenKey;
   connectionId?: string | null;
+  notebookId?: string | null;
 }
 
 export default class MainDatabaseService {
@@ -129,6 +130,7 @@ export default class MainDatabaseService {
         provider_id INTEGER,
         screen_key TEXT DEFAULT 'project',
         connection_id TEXT,
+        notebook_id TEXT,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now')),
         FOREIGN KEY (provider_id) REFERENCES ai_providers(id) ON DELETE SET NULL
@@ -309,6 +311,14 @@ export default class MainDatabaseService {
         );
         alterStatements.push(
           'CREATE INDEX IF NOT EXISTS chat_conversations_connection_idx ON chat_conversations(connection_id);',
+        );
+      }
+      if (!chatConvCols.has('notebook_id')) {
+        alterStatements.push(
+          'ALTER TABLE chat_conversations ADD COLUMN notebook_id TEXT;',
+        );
+        alterStatements.push(
+          'CREATE INDEX IF NOT EXISTS chat_conversations_notebook_idx ON chat_conversations(notebook_id);',
         );
       }
 
@@ -561,6 +571,7 @@ export default class MainDatabaseService {
     providerId?: number,
     screenKey?: AgentScreenKey,
     connectionId?: string,
+    notebookId?: string,
   ): Promise<ChatConversation> {
     const db = await this.getDatabase();
 
@@ -573,6 +584,7 @@ export default class MainDatabaseService {
           providerId,
           screenKey: screenKey ?? 'project',
           connectionId,
+          notebookId,
         })
         .returning();
 
@@ -607,6 +619,15 @@ export default class MainDatabaseService {
         } else {
           conditions.push(
             eq(schema.chatConversations.connectionId, opts.connectionId),
+          );
+        }
+      }
+      if (opts.notebookId !== undefined) {
+        if (opts.notebookId === null) {
+          conditions.push(isNull(schema.chatConversations.notebookId));
+        } else {
+          conditions.push(
+            eq(schema.chatConversations.notebookId, opts.notebookId),
           );
         }
       }

--- a/src/main/services/notebooks.service.ts
+++ b/src/main/services/notebooks.service.ts
@@ -72,6 +72,14 @@ function isRowReturningQuery(query: string): boolean {
   return /^\s*(?:WITH\b[\s\S]*?\)\s*)*SELECT\b/i.test(query.trim());
 }
 
+// Strip trailing LIMIT/OFFSET clauses to allow backend pagination to work deterministically
+function removeTrailingLimit(query: string): string {
+  let cleaned = query.trim().replace(/;$/, '').trim();
+  const limitRegex = /\bLIMIT\s+\d+(?:\s+OFFSET\s+\d+)?\s*$/i;
+  cleaned = cleaned.replace(limitRegex, '').trim();
+  return cleaned;
+}
+
 // Ensure directories exist
 async function ensureDirectories() {
   await fs.mkdir(NOTEBOOKS_DIR, { recursive: true });
@@ -684,8 +692,11 @@ export class NotebooksService {
       // Validate and sanitize pagination inputs
       const { pageLimit, pageOffset } = sanitizePagination(limit, offset);
 
+      // Strip any explicit LIMIT/OFFSET to avoid syntax errors when we append ours
+      const processedSql = removeTrailingLimit(sql);
+
       // Detect query type - includes WITH...SELECT and other row-returning queries
-      const isSelect = isRowReturningQuery(sql);
+      const isSelect = isRowReturningQuery(processedSql);
 
       let result: any;
       let totalRows: number | undefined;
@@ -697,7 +708,7 @@ export class NotebooksService {
         // DuckLake supports native pagination
         result = await DuckLakeService.executeQuery({
           instanceId,
-          query: sql,
+          query: processedSql,
           limit: isSelect ? pageLimit : undefined,
           offset: isSelect ? pageOffset : undefined,
         });
@@ -710,7 +721,7 @@ export class NotebooksService {
           result.data.length > 0
         ) {
           try {
-            const countQuery = `SELECT COUNT(*) as count FROM (${sql.trim().replace(/;$/, '')}) as subquery`;
+            const countQuery = `SELECT COUNT(*) as count FROM (${processedSql.trim().replace(/;$/, '')}) as subquery`;
             const countResult = await DuckLakeService.executeQuery({
               instanceId,
               query: countQuery,
@@ -727,11 +738,11 @@ export class NotebooksService {
         }
       } else {
         // Regular DB connection
-        let queryToExecute = sql;
+        let queryToExecute = processedSql;
 
         // Manually append LIMIT/OFFSET for SELECT queries
         if (isSelect) {
-          queryToExecute = `${sql.trim().replace(/;$/, '')} LIMIT ${pageLimit} OFFSET ${pageOffset}`;
+          queryToExecute = `${processedSql.trim().replace(/;$/, '')} LIMIT ${pageLimit} OFFSET ${pageOffset}`;
         }
 
         result = await ConnectorsService.executeQueryForConnection({
@@ -747,7 +758,7 @@ export class NotebooksService {
           result.data.length > 0
         ) {
           try {
-            const countQuery = `SELECT COUNT(*) as count FROM (${sql.trim().replace(/;$/, '')}) as subquery`;
+            const countQuery = `SELECT COUNT(*) as count FROM (${processedSql.trim().replace(/;$/, '')}) as subquery`;
             const countResult =
               await ConnectorsService.executeQueryForConnection({
                 connectionId,
@@ -844,7 +855,8 @@ export class NotebooksService {
       const { pageLimit, pageOffset } = sanitizePagination(limit, offset);
 
       // Detect query type - includes WITH...SELECT and other row-returning queries
-      const isSelect = isRowReturningQuery(sql);
+      const processedSql = removeTrailingLimit(sql);
+      const isSelect = isRowReturningQuery(processedSql);
 
       // Only paginate SELECT queries
       if (!isSelect) {
@@ -865,7 +877,7 @@ export class NotebooksService {
         // DuckLake supports native pagination
         result = await DuckLakeService.executeQuery({
           instanceId,
-          query: sql,
+          query: processedSql,
           limit: pageLimit,
           offset: pageOffset,
         });
@@ -873,7 +885,7 @@ export class NotebooksService {
         // Get total row count
         if (result.success && result.data) {
           try {
-            const countQuery = `SELECT COUNT(*) as count FROM (${sql.trim().replace(/;$/, '')}) as subquery`;
+            const countQuery = `SELECT COUNT(*) as count FROM (${processedSql.trim().replace(/;$/, '')}) as subquery`;
             const countResult = await DuckLakeService.executeQuery({
               instanceId,
               query: countQuery,
@@ -889,7 +901,7 @@ export class NotebooksService {
         }
       } else {
         // Regular DB connection - manually append LIMIT/OFFSET with sanitized values
-        const queryToExecute = `${sql.trim().replace(/;$/, '')} LIMIT ${pageLimit} OFFSET ${pageOffset}`;
+        const queryToExecute = `${processedSql.trim().replace(/;$/, '')} LIMIT ${pageLimit} OFFSET ${pageOffset}`;
 
         result = await ConnectorsService.executeQueryForConnection({
           connectionId,
@@ -899,7 +911,7 @@ export class NotebooksService {
         // Get total row count
         if (result.success && result.data) {
           try {
-            const countQuery = `SELECT COUNT(*) as count FROM (${sql.trim().replace(/;$/, '')}) as subquery`;
+            const countQuery = `SELECT COUNT(*) as count FROM (${processedSql.trim().replace(/;$/, '')}) as subquery`;
             const countResult =
               await ConnectorsService.executeQueryForConnection({
                 connectionId,

--- a/src/renderer/components/chat/ChatInputBox.tsx
+++ b/src/renderer/components/chat/ChatInputBox.tsx
@@ -51,6 +51,7 @@ interface ChatInputBoxProps {
   onCancelStream?: () => void;
   contextBreakdown?: ContextUsageBreakdown | null;
   screenKey?: string;
+  disabledReason?: string | null;
 }
 
 export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
@@ -61,6 +62,7 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
   onCancelStream,
   contextBreakdown,
   screenKey,
+  disabledReason,
 }) => {
   const theme = useTheme();
   const [input, setInput] = React.useState('');
@@ -89,6 +91,8 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
   // All messages now route through the agent path
   const isLoading = isStreaming;
   const isCanceling = false;
+  const isBlocked = !!disabledReason;
+  const inputDisabled = isLoading || isBlocked;
 
   // Auto-rename session hook
   const { autoRename } = useAutoRenameSession(sessionId);
@@ -158,6 +162,8 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
   };
 
   const handleSendMessage = async (content?: string) => {
+    if (disabledReason) return;
+
     const messageContent = content || plainText.trim();
     const limitError = getUserMessageLimitError(
       messageContent,
@@ -179,14 +185,20 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
   };
 
   React.useEffect(() => {
-    if (pendingMessage && sessionId && activeProvider && !isLoading) {
+    if (
+      pendingMessage &&
+      sessionId &&
+      activeProvider &&
+      !isLoading &&
+      !disabledReason
+    ) {
       setTimeout(() => {
         handleSendMessage(pendingMessage);
         setPendingMessage(null);
         setInput('');
       }, 500);
     }
-  }, [pendingMessage, sessionId, activeProvider, isLoading]);
+  }, [pendingMessage, sessionId, activeProvider, isLoading, disabledReason]);
 
   return (
     <Box
@@ -220,8 +232,8 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
           <TipTapEditor
             value={input}
             onChange={setInput}
-            placeholder="Type a message..."
-            disabled={isLoading}
+            placeholder={disabledReason ?? 'Type a message...'}
+            disabled={inputDisabled}
             onSubmit={handleSend}
           />
         </Box>
@@ -239,14 +251,19 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
         {screenKey !== 'sql' && (
           <>
             <Tooltip
-              title="Add context..."
+              title={disabledReason ?? 'Add context...'}
               placement="top"
               arrow
               enterDelay={500}
             >
               <IconButton
                 size="small"
-                onClick={() => setIsFilePickerOpen(true)}
+                onClick={() => {
+                  if (!isBlocked) {
+                    setIsFilePickerOpen(true);
+                  }
+                }}
+                disabled={isBlocked}
                 sx={{
                   width: 20,
                   height: 20,
@@ -289,7 +306,11 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
 
         {/* Agent/Chat Mode Selector - Custom Dropdown */}
         <Box
-          onClick={(e) => !isLoading && setModeMenuAnchor(e.currentTarget)}
+          onClick={(e) => {
+            if (!inputDisabled) {
+              setModeMenuAnchor(e.currentTarget);
+            }
+          }}
           sx={{
             display: 'flex',
             alignItems: 'center',
@@ -300,9 +321,10 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
             py: 0.125,
             border: '1px solid',
             borderColor: 'divider',
-            cursor: isLoading ? 'default' : 'pointer',
+            opacity: isBlocked ? 0.6 : 1,
+            cursor: inputDisabled ? 'default' : 'pointer',
             '&:hover': {
-              bgcolor: isLoading ? 'transparent' : 'action.hover',
+              bgcolor: inputDisabled ? 'transparent' : 'action.hover',
             },
           }}
         >
@@ -328,7 +350,9 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
         {/* AI Provider Selector - Custom Dropdown */}
         <Box
           onClick={(e) =>
-            !switching && !isLoading && setProviderMenuAnchor(e.currentTarget)
+            !switching &&
+            !inputDisabled &&
+            setProviderMenuAnchor(e.currentTarget)
           }
           sx={{
             display: 'flex',
@@ -340,9 +364,11 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
             py: 0.125,
             border: '1px solid',
             borderColor: 'divider',
-            cursor: switching || isLoading ? 'default' : 'pointer',
+            opacity: isBlocked ? 0.6 : 1,
+            cursor: switching || inputDisabled ? 'default' : 'pointer',
             '&:hover': {
-              bgcolor: switching || isLoading ? 'transparent' : 'action.hover',
+              bgcolor:
+                switching || inputDisabled ? 'transparent' : 'action.hover',
             },
           }}
         >
@@ -561,13 +587,16 @@ export const ChatInputBox: React.FC<ChatInputBoxProps> = ({
           }
 
           const sendDisabled =
+            isBlocked ||
             !sessionId ||
             !plainText.trim() ||
             !!messageLimitError ||
             !activeProvider ||
             activeContextManager.isResolvingContext;
           let tooltipTitle = 'Send message (Enter)';
-          if (!activeProvider) tooltipTitle = 'Select an AI provider to send';
+          if (disabledReason) tooltipTitle = disabledReason;
+          else if (!activeProvider)
+            tooltipTitle = 'Select an AI provider to send';
           else if (!sessionId) tooltipTitle = 'Open or create a chat session';
           else if (!plainText.trim())
             tooltipTitle = 'Type a message to enable send';

--- a/src/renderer/components/chat/ChatMessageList.tsx
+++ b/src/renderer/components/chat/ChatMessageList.tsx
@@ -7,6 +7,15 @@ import {
   CircularProgress,
 } from '@mui/material';
 import ChatIcon from '@mui/icons-material/Chat';
+import CodeIcon from '@mui/icons-material/Code';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import BugReportIcon from '@mui/icons-material/BugReport';
+import PsychologyIcon from '@mui/icons-material/Psychology';
+import AccountTreeIcon from '@mui/icons-material/AccountTree';
+import TipsAndUpdatesIcon from '@mui/icons-material/TipsAndUpdates';
+import HistoryEduIcon from '@mui/icons-material/HistoryEdu';
+import ExploreIcon from '@mui/icons-material/Explore';
 import { useGetChatMessagesWithContext } from '../../controllers/chat.controller';
 import { useGetAISettings } from '../../controllers/aiSettings.controller';
 import { MessageRenderer } from './MessageRenderer';
@@ -144,9 +153,18 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = ({
         subtitle:
           'Run queries, inspect schema, and iterate faster with connection-aware assistance.',
         bullets: [
-          'Write and refine SQL for the active connection',
-          'Explain query errors and suggest safe fixes',
-          'Generate quick exploration queries from plain language',
+          {
+            text: 'Write and refine SQL for the active connection',
+            icon: <CodeIcon sx={{ fontSize: '0.9rem' }} />,
+          },
+          {
+            text: 'Explain query errors and suggest safe fixes',
+            icon: <ErrorOutlineIcon sx={{ fontSize: '0.9rem' }} />,
+          },
+          {
+            text: 'Generate quick exploration queries from plain language',
+            icon: <AutoFixHighIcon sx={{ fontSize: '0.9rem' }} />,
+          },
         ],
       };
     }
@@ -157,9 +175,18 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = ({
         subtitle:
           'Build analysis workflows cell by cell with context from your notebook and connection.',
         bullets: [
-          'Draft SQL cells from analysis goals',
-          'Help debug failing cells and outputs',
-          'Propose next steps for data investigation',
+          {
+            text: 'Draft SQL cells from analysis goals',
+            icon: <HistoryEduIcon sx={{ fontSize: '0.9rem' }} />,
+          },
+          {
+            text: 'Help debug failing cells and outputs',
+            icon: <BugReportIcon sx={{ fontSize: '0.9rem' }} />,
+          },
+          {
+            text: 'Propose next steps for data investigation',
+            icon: <PsychologyIcon sx={{ fontSize: '0.9rem' }} />,
+          },
         ],
       };
     }
@@ -169,9 +196,18 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = ({
       subtitle:
         'Use the dbt agent to plan, write, and improve models with project context.',
       bullets: [
-        'Create or refactor dbt models and tests',
-        'Explain lineage and transformation intent',
-        'Suggest best-practice project improvements',
+        {
+          text: 'Create or refactor dbt models and tests',
+          icon: <AccountTreeIcon sx={{ fontSize: '0.9rem' }} />,
+        },
+        {
+          text: 'Explain lineage and transformation intent',
+          icon: <ExploreIcon sx={{ fontSize: '0.9rem' }} />,
+        },
+        {
+          text: 'Suggest best-practice project improvements',
+          icon: <TipsAndUpdatesIcon sx={{ fontSize: '0.9rem' }} />,
+        },
       ],
     };
   }, [screenKey]);
@@ -227,19 +263,18 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = ({
           Loading messages...
         </Typography>
       )}
-      {!isLoading && messages.length === 0 && !isAgentRunning && (
-        <Box sx={{ px: 1.5, pt: 1, pb: 1.5 }}>
-          <Box
-            sx={{
-              border: '1px solid',
-              borderColor: 'divider',
-              borderRadius: 0.5,
-              px: 1.5,
-              py: 1.25,
-              background:
-                'linear-gradient(180deg, rgba(144,202,249,0.08) 0%, rgba(144,202,249,0.02) 100%)',
-            }}
-          >
+      {!isLoading && messages.length === 0 && !isAgentRunning ? (
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            px: 3,
+            textAlign: 'center',
+          }}
+        >
+          <Stack spacing={1} sx={{ maxWidth: 420, alignItems: 'center' }}>
             <Typography
               variant="body2"
               sx={{ fontWeight: 600, color: 'text.primary' }}
@@ -248,249 +283,271 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = ({
             </Typography>
             <Typography
               variant="caption"
-              sx={{
-                color: 'text.secondary',
-                display: 'block',
-                mt: 0.5,
-                lineHeight: 1.5,
-              }}
+              sx={{ color: 'text.secondary', lineHeight: 1.5 }}
             >
               {emptyState.subtitle}
             </Typography>
-            <Stack sx={{ mt: 1 }} spacing={0.5}>
+            <Stack spacing={0.75} sx={{ alignItems: 'flex-start' }}>
               {emptyState.bullets.map((item) => (
-                <Typography
-                  key={item}
-                  variant="caption"
-                  sx={{ color: 'text.secondary', lineHeight: 1.45 }}
+                <Box
+                  key={item.text}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    color: 'text.secondary',
+                    textAlign: 'left',
+                  }}
                 >
-                  • {item}
-                </Typography>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      color: 'primary.main',
+                      opacity: 0.8,
+                    }}
+                  >
+                    {item.icon}
+                  </Box>
+                  <Typography variant="caption" sx={{ lineHeight: 1.45 }}>
+                    {item.text}
+                  </Typography>
+                </Box>
               ))}
             </Stack>
-          </Box>
+          </Stack>
         </Box>
-      )}
-      <Stack
-        spacing={0.25}
-        sx={{ minWidth: 0, overflowX: 'hidden', px: 1.5, pb: '50px' }}
-      >
-        {messages.map((m, index) => {
-          if (m.role === 'system' && (m.metadata as any)?.compacted) {
-            const summarizedCount =
-              (m.metadata as any)?.summarizedMessageCount ??
-              compactionInfo?.messagesSummarized;
-            return (
-              <Box
-                key={m.id}
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  my: 0.5,
-                  opacity: 0.55,
-                }}
-              >
-                <Divider sx={{ flex: 1 }} />
-                <Typography
-                  variant="caption"
+      ) : (
+        <Stack
+          spacing={0.25}
+          sx={{ minWidth: 0, overflowX: 'hidden', px: 1.5, pb: '50px' }}
+        >
+          {messages.map((m, index) => {
+            if (m.role === 'system' && (m.metadata as any)?.compacted) {
+              const summarizedCount =
+                (m.metadata as any)?.summarizedMessageCount ??
+                compactionInfo?.messagesSummarized;
+              return (
+                <Box
+                  key={m.id}
                   sx={{
-                    mx: 1.5,
-                    color: 'text.disabled',
-                    fontSize: '0.65rem',
-                    whiteSpace: 'nowrap',
+                    display: 'flex',
+                    alignItems: 'center',
+                    my: 0.5,
+                    opacity: 0.55,
                   }}
                 >
-                  Earlier conversation summarized
-                  {summarizedCount ? ` (${summarizedCount} messages)` : ''}
-                </Typography>
-                <Divider sx={{ flex: 1 }} />
-              </Box>
+                  <Divider sx={{ flex: 1 }} />
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      mx: 1.5,
+                      color: 'text.disabled',
+                      fontSize: '0.65rem',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    Earlier conversation summarized
+                    {summarizedCount ? ` (${summarizedCount} messages)` : ''}
+                  </Typography>
+                  <Divider sx={{ flex: 1 }} />
+                </Box>
+              );
+            }
+
+            const isLastMessage = index === messages.length - 1;
+            const persistedUsage =
+              m.metadata?.promptTokens ||
+              m.metadata?.completionTokens ||
+              m.metadata?.totalTokens
+                ? {
+                    promptTokens: m.metadata?.promptTokens ?? 0,
+                    completionTokens: m.metadata?.completionTokens ?? 0,
+                    totalTokens: m.metadata?.totalTokens ?? 0,
+                  }
+                : null;
+            return (
+              <React.Fragment key={m.id}>
+                <MessageRenderer
+                  messageId={m.id}
+                  content={m.content || ''}
+                  role={m.role}
+                  contextItems={m.contextItems}
+                  toolCalls={m.toolCalls?.length > 0 ? m.toolCalls : undefined}
+                  reasoning={
+                    (m as any).reasoning ||
+                    (m.thinkingContent
+                      ? { text: m.thinkingContent }
+                      : undefined)
+                  }
+                  isStreaming={false}
+                  tokenUsage={
+                    persistedUsage ||
+                    (isLastMessage && m.role === 'assistant' ? lastUsage : null)
+                  }
+                  showTokenCount={aiSettings?.chat?.showTokenCount}
+                  orderedParts={m.metadata?.orderedParts}
+                />
+              </React.Fragment>
             );
-          }
+          })}
 
-          const isLastMessage = index === messages.length - 1;
-          const persistedUsage =
-            m.metadata?.promptTokens ||
-            m.metadata?.completionTokens ||
-            m.metadata?.totalTokens
-              ? {
-                  promptTokens: m.metadata?.promptTokens ?? 0,
-                  completionTokens: m.metadata?.completionTokens ?? 0,
-                  totalTokens: m.metadata?.totalTokens ?? 0,
-                }
-              : null;
-          return (
-            <React.Fragment key={m.id}>
-              <MessageRenderer
-                messageId={m.id}
-                content={m.content || ''}
-                role={m.role}
-                contextItems={m.contextItems}
-                toolCalls={m.toolCalls?.length > 0 ? m.toolCalls : undefined}
-                reasoning={
-                  (m as any).reasoning ||
-                  (m.thinkingContent ? { text: m.thinkingContent } : undefined)
-                }
-                isStreaming={false}
-                tokenUsage={
-                  persistedUsage ||
-                  (isLastMessage && m.role === 'assistant' ? lastUsage : null)
-                }
-                showTokenCount={aiSettings?.chat?.showTokenCount}
-                orderedParts={m.metadata?.orderedParts}
-              />
-            </React.Fragment>
-          );
-        })}
-
-        {/* Compaction divider — shown when auto-compaction fired this session */}
-        {compactionInfo && !hasPersistedCompaction && (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              my: 0.5,
-              opacity: 0.55,
-            }}
-          >
-            <Divider sx={{ flex: 1 }} />
-            <Typography
-              variant="caption"
+          {/* Compaction divider — shown when auto-compaction fired this session */}
+          {compactionInfo && !hasPersistedCompaction && (
+            <Box
               sx={{
-                mx: 1.5,
-                color: 'text.disabled',
-                fontSize: '0.65rem',
-                whiteSpace: 'nowrap',
+                display: 'flex',
+                alignItems: 'center',
+                my: 0.5,
+                opacity: 0.55,
               }}
             >
-              Earlier conversation summarized (
-              {compactionInfo.messagesSummarized} messages)
-            </Typography>
-            <Divider sx={{ flex: 1 }} />
-          </Box>
-        )}
+              <Divider sx={{ flex: 1 }} />
+              <Typography
+                variant="caption"
+                sx={{
+                  mx: 1.5,
+                  color: 'text.disabled',
+                  fontSize: '0.65rem',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Earlier conversation summarized (
+                {compactionInfo.messagesSummarized} messages)
+              </Typography>
+              <Divider sx={{ flex: 1 }} />
+            </Box>
+          )}
 
-        {/* Live interleaved stream — text parts + tool-call parts in arrival order */}
-        {(streamState?.contentParts.length ?? 0) > 0 &&
-          (() => {
-            // Hide once the run is fully persisted (DB message with tool calls loaded)
-            const lastMsg = messages[messages.length - 1];
-            const alreadyPersisted =
-              !isAgentRunning &&
-              lastMsg?.role === 'assistant' &&
-              lastMsg?.toolCalls?.length > 0;
-            if (alreadyPersisted) return null;
+          {/* Live interleaved stream — text parts + tool-call parts in arrival order */}
+          {(streamState?.contentParts.length ?? 0) > 0 &&
+            (() => {
+              // Hide once the run is fully persisted (DB message with tool calls loaded)
+              const lastMsg = messages[messages.length - 1];
+              const alreadyPersisted =
+                !isAgentRunning &&
+                lastMsg?.role === 'assistant' &&
+                lastMsg?.toolCalls?.length > 0;
+              if (alreadyPersisted) return null;
 
-            return (
-              <Box sx={{ mt: 0.25 }}>
-                {streamState!.contentParts.map((part, idx) => {
-                  if (part.type === 'text') {
-                    // Only render non-empty text parts
-                    if (!part.text) return null;
-                    const assistantRole = 'assistant' as const;
+              return (
+                <Box sx={{ mt: 0.25 }}>
+                  {streamState!.contentParts.map((part, idx) => {
+                    if (part.type === 'text') {
+                      // Only render non-empty text parts
+                      if (!part.text) return null;
+                      const assistantRole = 'assistant' as const;
+                      return (
+                        <MessageRenderer
+                          // eslint-disable-next-line react/no-array-index-key
+                          key={`live-text-${idx}`}
+                          messageId={-1}
+                          role={assistantRole}
+                          content={part.text}
+                          isStreaming={!!isAgentRunning}
+                        />
+                      );
+                    }
+                    // tool-call part
+                    const tc = part as ToolCallContentPart;
                     return (
-                      <MessageRenderer
-                        // eslint-disable-next-line react/no-array-index-key
-                        key={`live-text-${idx}`}
-                        messageId={-1}
-                        role={assistantRole}
-                        content={part.text}
-                        isStreaming={!!isAgentRunning}
+                      <ToolCallRow
+                        key={tc.toolCallId}
+                        toolCall={{
+                          id: tc.toolCallId,
+                          toolName: tc.toolName,
+                          args: tc.args,
+                          result: tc.result,
+                          error: tc.error,
+                          status: tc.status,
+                          durationMs: tc.durationMs,
+                        }}
                       />
                     );
-                  }
-                  // tool-call part
-                  const tc = part as ToolCallContentPart;
-                  return (
-                    <ToolCallRow
-                      key={tc.toolCallId}
-                      toolCall={{
-                        id: tc.toolCallId,
-                        toolName: tc.toolName,
-                        args: tc.args,
-                        result: tc.result,
-                        error: tc.error,
-                        status: tc.status,
-                        durationMs: tc.durationMs,
-                      }}
-                    />
-                  );
-                })}
-              </Box>
-            );
-          })()}
+                  })}
+                </Box>
+              );
+            })()}
 
-        {/* Terminal confirmation banner — below the streaming text */}
-        {streamState?.pendingConfirm && onConfirmTerminal && (
-          <TerminalConfirmBanner
-            request={streamState.pendingConfirm}
-            onAllow={() => onConfirmTerminal(true)}
-            onDeny={() => onConfirmTerminal(false)}
-          />
-        )}
+          {/* Terminal confirmation banner — below the streaming text */}
+          {streamState?.pendingConfirm && onConfirmTerminal && (
+            <TerminalConfirmBanner
+              request={streamState.pendingConfirm}
+              onAllow={() => onConfirmTerminal(true)}
+              onDeny={() => onConfirmTerminal(false)}
+            />
+          )}
 
-        {/* Agent error alert */}
-        {streamState?.error && onClearError && (
-          <AgentErrorAlert error={streamState.error} onDismiss={onClearError} />
-        )}
+          {/* Agent error alert */}
+          {streamState?.error && onClearError && (
+            <AgentErrorAlert
+              error={streamState.error}
+              onDismiss={onClearError}
+            />
+          )}
 
-        {/* Global persistent Working... — visible throughout the entire generation cycle.
+          {/* Global persistent Working... — visible throughout the entire generation cycle.
             Appears below all tool calls, TerminalGate, and error banners.
             Disappears only when generation fully stops. */}
-        {isAgentRunning && !streamState?.error && (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 0.75,
-              px: 0.5,
-              py: 0.75,
-              color: 'text.disabled',
-            }}
-          >
-            <CircularProgress size={10} color="inherit" sx={{ opacity: 0.6 }} />
-            <Typography
-              variant="caption"
+          {isAgentRunning && !streamState?.error && (
+            <Box
               sx={{
-                color: 'text.secondary',
-                fontSize: '0.72rem',
-                fontStyle: 'italic',
-                '@keyframes workingPulse': {
-                  '0%, 100%': { opacity: 0.45 },
-                  '50%': { opacity: 1 },
-                },
-                animation: 'workingPulse 1.6s ease-in-out infinite',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.75,
+                px: 0.5,
+                py: 0.75,
+                color: 'text.disabled',
               }}
             >
-              {streamState?.pendingConfirm
-                ? 'Waiting for user input'
-                : 'Working'}
-            </Typography>
-            {!streamState?.pendingConfirm &&
-              [0, 1, 2].map((i) => (
-                <Box
-                  key={i}
-                  sx={{
-                    width: 3,
-                    height: 3,
-                    borderRadius: '50%',
-                    bgcolor: 'text.disabled',
-                    '@keyframes workingDot': {
-                      '0%, 80%, 100%': {
-                        transform: 'scale(0.6)',
-                        opacity: 0.35,
+              <CircularProgress
+                size={10}
+                color="inherit"
+                sx={{ opacity: 0.6 }}
+              />
+              <Typography
+                variant="caption"
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: '0.72rem',
+                  fontStyle: 'italic',
+                  '@keyframes workingPulse': {
+                    '0%, 100%': { opacity: 0.45 },
+                    '50%': { opacity: 1 },
+                  },
+                  animation: 'workingPulse 1.6s ease-in-out infinite',
+                }}
+              >
+                {streamState?.pendingConfirm
+                  ? 'Waiting for user input'
+                  : 'Working'}
+              </Typography>
+              {!streamState?.pendingConfirm &&
+                [0, 1, 2].map((i) => (
+                  <Box
+                    key={i}
+                    sx={{
+                      width: 3,
+                      height: 3,
+                      borderRadius: '50%',
+                      bgcolor: 'text.disabled',
+                      '@keyframes workingDot': {
+                        '0%, 80%, 100%': {
+                          transform: 'scale(0.6)',
+                          opacity: 0.35,
+                        },
+                        '40%': { transform: 'scale(1)', opacity: 0.85 },
                       },
-                      '40%': { transform: 'scale(1)', opacity: 0.85 },
-                    },
-                    animation: `workingDot 1.2s ease-in-out ${i * 0.2}s infinite`,
-                  }}
-                />
-              ))}
-          </Box>
-        )}
+                      animation: `workingDot 1.2s ease-in-out ${i * 0.2}s infinite`,
+                    }}
+                  />
+                ))}
+            </Box>
+          )}
 
-        <div ref={bottomRef} />
-      </Stack>
+          <div ref={bottomRef} />
+        </Stack>
+      )}
     </Box>
   );
 };

--- a/src/renderer/components/chat/ChatWindow.tsx
+++ b/src/renderer/components/chat/ChatWindow.tsx
@@ -14,7 +14,7 @@ import { Close, MoreHoriz, Add as AddIcon, Tag } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useAppContext } from '../../hooks';
-import { useGetSelectedProject, useGetConnectionById } from '../../controllers';
+import { useGetSelectedProject } from '../../controllers';
 import {
   useCreateChatSession,
   useGetChatSessions,
@@ -77,9 +77,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       ? propProjectId
       : (project?.id as number | undefined);
   const navigate = useNavigate();
-
-  const { data: activeConnection } = useGetConnectionById(connectionId);
-  const connectionName = activeConnection?.connection?.name;
 
   const [selectedSessionId, setSelectedSessionId] = React.useState<number>();
   const previousScopeKeyRef = React.useRef<string | null>(null);
@@ -195,11 +192,32 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     return { label: badge.label, color: badge.color, tooltip: tooltipText };
   }, [screenKey, projectId]);
 
-  const { data: sessions = [], isLoading } = useGetChatSessions({
-    projectId: projectId ?? undefined,
-    screenKey,
-    connectionId: connectionId ?? null,
-  });
+  const disabledReason = React.useMemo(() => {
+    if (screenKey !== 'notebooks') return null;
+    if (!connectionId) return 'Select a connection to start AI Agent';
+    if (!notebookId) return 'Select a notebook to start AI Agent';
+    return null;
+  }, [screenKey, connectionId, notebookId]);
+
+  const canUseChatScope = React.useMemo(() => {
+    if (screenKey === 'notebooks') {
+      return !disabledReason;
+    }
+
+    return Boolean(projectId || connectionId || notebookId);
+  }, [screenKey, disabledReason, projectId, connectionId, notebookId]);
+
+  const { data: sessions = [], isLoading } = useGetChatSessions(
+    {
+      projectId: projectId ?? undefined,
+      screenKey,
+      connectionId: connectionId ?? null,
+      notebookId: notebookId ?? null,
+    },
+    {
+      enabled: canUseChatScope,
+    },
+  );
 
   const sessionScopeKey = React.useMemo(
     () =>
@@ -245,6 +263,12 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   const isCreatingRef = React.useRef(false);
 
   React.useEffect(() => {
+    if (!canUseChatScope) {
+      previousScopeKeyRef.current = sessionScopeKey;
+      setSelectedSessionId(undefined);
+      return;
+    }
+
     if (isLoading || isCreatingRef.current) return;
 
     const previousScopeKey = previousScopeKeyRef.current;
@@ -273,7 +297,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       });
       return;
     }
-    if (projectId || connectionId || notebookId) {
+    if (canUseChatScope) {
       // Auto-create a default chat session for the project or connection
       isCreatingRef.current = true;
       createSession({
@@ -291,6 +315,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     connectionId,
     notebookId,
     screenKey,
+    canUseChatScope,
     sessionScopeKey,
     createSession,
   ]);
@@ -303,7 +328,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   }, [isCreating]);
 
   const handleCreateNewSession = () => {
-    if (projectId || connectionId || notebookId) {
+    if (canUseChatScope) {
       const sessionCount = sessions.length;
       const title = `Chat ${sessionCount + 1}`;
       createSession({
@@ -472,6 +497,30 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   };
 
   const renderMessages = () => {
+    if (disabledReason) {
+      return (
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 1.5,
+            textAlign: 'center',
+            px: 3,
+          }}
+        >
+          <Typography variant="subtitle1" fontWeight={600}>
+            AI Agent Disabled
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {disabledReason}
+          </Typography>
+        </Box>
+      );
+    }
+
     if (isLoadingProviders) {
       return (
         <Box
@@ -688,21 +737,6 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                   >
                     {activeSession.title}
                   </Typography>
-                  {connectionName && (
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        fontSize: '0.65rem',
-                        color: 'text.disabled',
-                        lineHeight: 1,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {connectionName}
-                    </Typography>
-                  )}
                 </>
               ) : null;
             })()}
@@ -744,7 +778,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         >
           <NewChatButton
             onCreate={handleCreateNewSession}
-            disabled={(!projectId && !connectionId) || isLoading}
+            disabled={!canUseChatScope || isLoading}
             loading={isCreating}
           />
 
@@ -754,7 +788,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
             onSelect={handleSessionSelect}
             onDelete={handleSessionDelete}
             onRename={handleSessionRename}
-            disabled={isLoading}
+            disabled={!canUseChatScope || isLoading}
           />
 
           <Tooltip title="More options">
@@ -835,6 +869,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
             contextManager={contextManager}
             isStreaming={streamState.isStreaming}
             screenKey={screenKey}
+            disabledReason={disabledReason}
             onStartStream={(content, contextItems, toolMode) =>
               // toolMode is now forwarded from ChatInputBox (owns the toggle state)
               startStream(

--- a/src/renderer/components/chat/ChatWindow.tsx
+++ b/src/renderer/components/chat/ChatWindow.tsx
@@ -46,6 +46,7 @@ import { projectsServices } from '../../services';
 export interface ChatWindowProps {
   screenKey?: 'project' | 'sql' | 'notebooks';
   connectionId?: string;
+  notebookId?: string;
   projectId?: number | null;
   onClose?: () => void;
 }
@@ -59,6 +60,7 @@ const SCREEN_BADGE: Record<string, { label: string; color: string }> = {
 export const ChatWindow: React.FC<ChatWindowProps> = ({
   screenKey = 'project',
   connectionId,
+  notebookId,
   projectId: propProjectId,
   onClose,
 }) => {
@@ -200,8 +202,9 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   });
 
   const sessionScopeKey = React.useMemo(
-    () => `${screenKey}|${projectId ?? 'none'}|${connectionId ?? 'none'}`,
-    [screenKey, projectId, connectionId],
+    () =>
+      `${screenKey}|${projectId ?? 'none'}|${connectionId ?? 'none'}|${notebookId ?? 'none'}`,
+    [screenKey, projectId, connectionId, notebookId],
   );
   const { data: providers = [], isLoading: isLoadingProviders } =
     useGetAIProviders();
@@ -270,7 +273,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
       });
       return;
     }
-    if (projectId || connectionId) {
+    if (projectId || connectionId || notebookId) {
       // Auto-create a default chat session for the project or connection
       isCreatingRef.current = true;
       createSession({
@@ -278,6 +281,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         projectId: projectId ?? undefined,
         screenKey,
         connectionId,
+        notebookId,
       });
     }
   }, [
@@ -285,6 +289,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
     isLoading,
     projectId,
     connectionId,
+    notebookId,
     screenKey,
     sessionScopeKey,
     createSession,
@@ -298,7 +303,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
   }, [isCreating]);
 
   const handleCreateNewSession = () => {
-    if (projectId || connectionId) {
+    if (projectId || connectionId || notebookId) {
       const sessionCount = sessions.length;
       const title = `Chat ${sessionCount + 1}`;
       createSession({
@@ -306,6 +311,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
         projectId: projectId ?? undefined,
         screenKey,
         connectionId,
+        notebookId,
       });
     }
   };
@@ -838,6 +844,7 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({
                 toolMode ?? currentMode,
                 screenKey,
                 connectionId,
+                notebookId,
               )
             }
             onCancelStream={cancelStream}

--- a/src/renderer/components/menu/index.tsx
+++ b/src/renderer/components/menu/index.tsx
@@ -287,7 +287,8 @@ export const Menu: React.FC<MenuProps> = ({ actions }) => {
           </Box>
         )}
         {((isProjectSelected && isOnProjectDetails) ||
-          location.pathname === '/app/sql') && (
+          location.pathname === '/app/sql' ||
+          location.pathname.startsWith('/app/notebooks')) && (
           <Tooltip title="AI Assistant (beta)">
             <IconButton
               onClick={() => setIsChatOpen?.(!isChatOpen)}

--- a/src/renderer/components/notebook/NotebookEditor.tsx
+++ b/src/renderer/components/notebook/NotebookEditor.tsx
@@ -46,6 +46,7 @@ import {
 import { NotebookToolbar } from './NotebookToolbar';
 import { NotebookCell } from './NotebookCell';
 import { useSchemaForConnection, useMonacoAutocomplete } from '../../hooks';
+import { useNotebookBridge } from '../../hooks/useNotebookBridge';
 
 // Module-level singleton for SQL completion provider
 let sharedCompletionProvider: any = null;
@@ -55,12 +56,15 @@ interface NotebookEditorProps {
   instanceId: string; // This is actually the connectionId
   notebookId: string;
   onOpenNotebook?: (notebook: Notebook, connectionId: string) => void; // Callback to open notebook in new tab
+  /** Called after a DDL/DML cell executes successfully so the parent can refresh the schema tree */
+  onSchemaChange?: () => void;
 }
 
 export const NotebookEditor: React.FC<NotebookEditorProps> = ({
   instanceId, // Rename for clarity: this is the connectionId
   notebookId,
   onOpenNotebook, // Callback to open notebook in new tab
+  onSchemaChange,
 }) => {
   const navigate = useNavigate();
   const connectionId = instanceId; // Use connectionId internally for clarity
@@ -444,6 +448,14 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
           limit: 10, // Default pagination: first 10 rows
           offset: 0,
         });
+
+        // If the executed statement may have changed the schema, notify the parent
+        if (
+          onSchemaChange &&
+          /^\s*(CREATE|DROP|ALTER|RENAME|TRUNCATE)/i.test(content.trim())
+        ) {
+          onSchemaChange();
+        }
       } catch (err) {
         // Error is already handled by React Query and displayed in output
         // Just log it for debugging
@@ -457,7 +469,7 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
         });
       }
     },
-    [connectionId, notebookId, runCell],
+    [connectionId, notebookId, runCell, onSchemaChange],
   );
 
   const handleExport = useCallback(() => {
@@ -608,6 +620,64 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
     }
   }, [notebook, connectionId, deleteNotebook, navigate]);
 
+  // Notebook Bridge for AI Agent
+  // useMemo ensures the handlers object is only recreated when its dependencies
+  // change — not on every render. This prevents useNotebookBridge's useEffect
+  // from continuously deregistering and re-registering all IPC listeners.
+  const bridgeHandlers = React.useMemo(
+    () => ({
+      getNotebookState: () => ({
+        notebookId,
+        notebookName: notebook?.name ?? '',
+        cells: localCells.map((c) => ({
+          id: c.id,
+          type: c.type,
+          order: c.order,
+          contentPreview: c.content.substring(0, 100),
+          hasOutput: !!c.output,
+          outputRowCount: c.output?.rowCount,
+        })),
+      }),
+      getCellContent: (cellId: string) => {
+        const cell = localCells.find((c) => c.id === cellId);
+        return cell?.content ?? '';
+      },
+      addCell: (content: string) => {
+        const cellId = uuidv4();
+        setLocalCells((prev) => {
+          const newCell = {
+            id: cellId,
+            type: 'sql' as const,
+            content,
+            order: prev.length,
+          };
+          const updated = [...prev, newCell];
+          if (notebookId && connectionId) {
+            updateNotebook.mutate({ connectionId, notebookId, cells: updated });
+          }
+          return updated;
+        });
+        return cellId;
+      },
+      setCellContent: (cellId: string, content: string) => {
+        handleUpdateCell(cellId, content);
+      },
+      runCell: (cellId: string) => {
+        const cell = localCells.find((c) => c.id === cellId);
+        if (cell) {
+          handleRunCell(cellId, cell.content);
+        }
+      },
+      getCellResult: (cellId: string) => {
+        const cell = localCells.find((c) => c.id === cellId);
+        return cell?.output;
+      },
+    }),
+    [localCells, handleUpdateCell, handleRunCell],
+  );
+
+  useNotebookBridge(bridgeHandlers);
+
   if (isLoading) {
     return (
       <Box
@@ -642,7 +712,9 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
   }
 
   return (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+    <Box
+      sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}
+    >
       {/* Toolbar */}
       <NotebookToolbar
         notebook={notebook}
@@ -711,87 +783,96 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
             </Box>
           </Box>
         ) : (
-          <DragDropContext onDragEnd={handleDragEnd}>
-            <Droppable droppableId="notebook-cells">
-              {(droppableProvided: DroppableProvided) => (
-                <Box
-                  ref={droppableProvided.innerRef}
-                  // eslint-disable-next-line react/jsx-props-no-spreading
-                  {...droppableProvided.droppableProps}
-                  sx={{ overflowY: 'auto', height: '100%', p: 3 }}
-                >
-                  {[...localCells]
-                    .sort((a, b) => a.order - b.order)
-                    .map((cell, index) => (
-                      <Draggable
-                        key={cell.id}
-                        draggableId={cell.id}
-                        index={index}
-                      >
-                        {(
-                          draggableProvided: DraggableProvided,
-                          snapshot: DraggableStateSnapshot,
-                        ) => (
-                          <Box
-                            ref={draggableProvided.innerRef}
-                            // eslint-disable-next-line react/jsx-props-no-spreading
-                            {...draggableProvided.draggableProps}
-                            sx={{
-                              opacity: snapshot.isDragging ? 0.8 : 1,
-                              transform: snapshot.isDragging
-                                ? 'rotate(2deg)'
-                                : 'none',
-                            }}
-                          >
-                            <NotebookCell
-                              cell={cell}
-                              index={index}
-                              connectionId={connectionId}
-                              notebookId={notebookId}
-                              isExecuting={
-                                executingCells.has(cell.id) ||
-                                (isRunningAll && runningCellIndex === index)
-                              }
-                              onRun={(content: string) =>
-                                handleRunCell(cell.id, content)
-                              }
-                              onUpdate={(content: string) =>
-                                handleUpdateCell(cell.id, content)
-                              }
-                              onDelete={() => handleDeleteCell(cell.id)}
-                              onDuplicate={() => handleDuplicateCell(cell.id)}
-                              onClearOutput={() => handleClearOutput(cell.id)}
-                              dragHandleProps={
-                                draggableProvided.dragHandleProps
-                              }
-                            />
-                          </Box>
-                        )}
-                      </Draggable>
-                    ))}
-                  {droppableProvided.placeholder}
-
-                  {/* Add Cell Button - inside scrollable area */}
+          <Box
+            sx={{
+              flex: 1,
+              minHeight: 0,
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <DragDropContext onDragEnd={handleDragEnd}>
+              <Droppable droppableId="notebook-cells">
+                {(droppableProvided: DroppableProvided) => (
                   <Box
-                    sx={{
-                      display: 'flex',
-                      justifyContent: 'center',
-                      mt: 2,
-                      pb: 4,
-                    }}
+                    ref={droppableProvided.innerRef}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...droppableProvided.droppableProps}
+                    sx={{ overflowY: 'auto', flex: 1, minHeight: 0, p: 3 }}
                   >
-                    <Button
-                      variant="outlined"
-                      startIcon={<AddIcon />}
-                      onClick={() => handleAddCell('sql')}
+                    {[...localCells]
+                      .sort((a, b) => a.order - b.order)
+                      .map((cell, index) => (
+                        <Draggable
+                          key={cell.id}
+                          draggableId={cell.id}
+                          index={index}
+                        >
+                          {(
+                            draggableProvided: DraggableProvided,
+                            snapshot: DraggableStateSnapshot,
+                          ) => (
+                            <Box
+                              ref={draggableProvided.innerRef}
+                              // eslint-disable-next-line react/jsx-props-no-spreading
+                              {...draggableProvided.draggableProps}
+                              sx={{
+                                opacity: snapshot.isDragging ? 0.8 : 1,
+                                transform: snapshot.isDragging
+                                  ? 'rotate(2deg)'
+                                  : 'none',
+                              }}
+                            >
+                              <NotebookCell
+                                cell={cell}
+                                index={index}
+                                connectionId={connectionId}
+                                notebookId={notebookId}
+                                isExecuting={
+                                  executingCells.has(cell.id) ||
+                                  (isRunningAll && runningCellIndex === index)
+                                }
+                                onRun={(content: string) =>
+                                  handleRunCell(cell.id, content)
+                                }
+                                onUpdate={(content: string) =>
+                                  handleUpdateCell(cell.id, content)
+                                }
+                                onDelete={() => handleDeleteCell(cell.id)}
+                                onDuplicate={() => handleDuplicateCell(cell.id)}
+                                onClearOutput={() => handleClearOutput(cell.id)}
+                                dragHandleProps={
+                                  draggableProvided.dragHandleProps
+                                }
+                              />
+                            </Box>
+                          )}
+                        </Draggable>
+                      ))}
+                    {droppableProvided.placeholder}
+
+                    {/* Add Cell Button - inside scrollable area */}
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        mt: 2,
+                        pb: 4,
+                      }}
                     >
-                      Add Cell
-                    </Button>
+                      <Button
+                        variant="outlined"
+                        startIcon={<AddIcon />}
+                        onClick={() => handleAddCell('sql')}
+                      >
+                        Add Cell
+                      </Button>
+                    </Box>
                   </Box>
-                </Box>
-              )}
-            </Droppable>
-          </DragDropContext>
+                )}
+              </Droppable>
+            </DragDropContext>
+          </Box>
         )}
       </Box>
 

--- a/src/renderer/components/settings/AISettingsTab.tsx
+++ b/src/renderer/components/settings/AISettingsTab.tsx
@@ -168,6 +168,37 @@ const TOOLS: ToolItem[] = [
     icon: <PatchIcon sx={{ fontSize: 16 }} />,
     planned: true,
   },
+  // ── Notebooks ─────────────────────────────────────────────────────────────
+  {
+    id: 'notebooks_get_state',
+    label: 'notebooks_get_state',
+    description: 'List all cells in the current notebook and their types',
+    icon: <SearchIcon sx={{ fontSize: 16 }} />,
+  },
+  {
+    id: 'notebooks_cell_read',
+    label: 'notebooks_cell_read',
+    description: 'Read the source code/content of a specific cell',
+    icon: <ArticleIcon sx={{ fontSize: 16 }} />,
+  },
+  {
+    id: 'notebooks_cell_update',
+    label: 'notebooks_cell_update',
+    description: 'Update the content of a notebook cell',
+    icon: <EditIcon sx={{ fontSize: 16 }} />,
+  },
+  {
+    id: 'notebooks_cell_run',
+    label: 'notebooks_cell_run',
+    description: 'Execute a specific notebook cell',
+    icon: <TerminalIcon sx={{ fontSize: 16 }} />,
+  },
+  {
+    id: 'notebooks_cell_result',
+    label: 'notebooks_cell_result',
+    description: 'Inspect the last execution result of a cell',
+    icon: <StorageIcon sx={{ fontSize: 16 }} />,
+  },
 ];
 
 // ─── Sub-components ───────────────────────────────────────────────────────────

--- a/src/renderer/controllers/chat.controller.ts
+++ b/src/renderer/controllers/chat.controller.ts
@@ -23,6 +23,7 @@ export interface GetSessionsFilter {
   projectId?: number;
   screenKey?: string;
   connectionId?: string | null;
+  notebookId?: string | null;
 }
 
 // Get all chat sessions
@@ -68,9 +69,9 @@ export const useCreateChatSession = (
     {
       title: string;
       projectId?: number;
-      providerId?: number;
       screenKey?: string;
       connectionId?: string;
+      notebookId?: string;
     }
   >,
 ): UseMutationResult<
@@ -79,9 +80,9 @@ export const useCreateChatSession = (
   {
     title: string;
     projectId?: number;
-    providerId?: number;
     screenKey?: string;
     connectionId?: string;
+    notebookId?: string;
   }
 > => {
   const { onSuccess: onCustomSuccess, onError: onCustomError } =
@@ -92,23 +93,23 @@ export const useCreateChatSession = (
     mutationFn: async ({
       title,
       projectId,
-      providerId,
       screenKey,
       connectionId,
+      notebookId,
     }) => {
       return chatService.createSession(
         title,
         projectId,
-        providerId,
         screenKey,
         connectionId,
+        notebookId,
       );
     },
     onSuccess: async (session, variables, ...args) => {
       await queryClient.invalidateQueries([QUERY_KEYS.GET_CHAT_SESSIONS]);
       await queryClient.invalidateQueries([
         QUERY_KEYS.GET_CHAT_SESSIONS,
-        variables.projectId,
+        { projectId: variables.projectId },
       ]);
       onCustomSuccess?.(session, variables, ...args);
     },

--- a/src/renderer/controllers/notebooks.controller.ts
+++ b/src/renderer/controllers/notebooks.controller.ts
@@ -271,12 +271,21 @@ export function useRunCell() {
         limit,
         offset,
       ),
-    onSuccess: async (_, { connectionId, notebookId }) => {
+    onSuccess: async (_, { connectionId, notebookId, sql }) => {
       // Manually refetch the notebook to get updated cell output
       await queryClient.refetchQueries(
         notebooksKeys.detail(connectionId, notebookId),
         { active: true }, // Only refetch if query is currently active
       );
+
+      if (
+        /^\s*(CREATE|DROP|ALTER|INSERT|UPDATE|DELETE|TRUNCATE|MERGE|REPLACE)/i.test(
+          sql,
+        )
+      ) {
+        queryClient.invalidateQueries(['schema', connectionId]);
+        queryClient.invalidateQueries(notebooksKeys.schema(connectionId));
+      }
     },
     onError: (error: Error) => {
       toast.error(`Cell execution failed: ${error.message}`);
@@ -334,6 +343,8 @@ export function useRunAllCells() {
       queryClient.invalidateQueries(
         notebooksKeys.detail(connectionId, notebookId),
       );
+      queryClient.invalidateQueries(['schema', connectionId]);
+      queryClient.invalidateQueries(notebooksKeys.schema(connectionId));
       toast.success('All cells executed');
     },
     onError: (error: Error) => {

--- a/src/renderer/hooks/useAgentStream.ts
+++ b/src/renderer/hooks/useAgentStream.ts
@@ -322,6 +322,7 @@ export const useAgentStream = (sessionId: number | undefined) => {
       toolMode?: 'chat' | 'agent',
       screenKey?: string,
       connectionId?: string,
+      notebookId?: string,
     ) => {
       if (!sessionId) return;
 
@@ -368,6 +369,7 @@ export const useAgentStream = (sessionId: number | undefined) => {
           toolMode,
           screenKey: screenKey as any,
           connectionId,
+          notebookId,
         });
 
         // Agent completed — replace optimistic message with persisted data

--- a/src/renderer/hooks/useNotebookBridge.ts
+++ b/src/renderer/hooks/useNotebookBridge.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import {
+  NotebookBridgeHandlers,
+  registerNotebookBridge,
+} from '../services/notebookBridge.service';
+
+export const useNotebookBridge = (
+  handlers: NotebookBridgeHandlers,
+  enabled: boolean = true,
+) => {
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    const unregister = registerNotebookBridge(handlers);
+    return () => {
+      unregister();
+    };
+  }, [handlers, enabled]);
+};

--- a/src/renderer/screens/notebooks/index.tsx
+++ b/src/renderer/screens/notebooks/index.tsx
@@ -58,13 +58,13 @@ import { connectorsServices, DuckLakeService } from '../../services';
 import { NotebooksSidebar } from '../../components/notebook/NotebooksSidebar';
 import { NotebookTabManager } from '../../components/notebook/NotebookTabManager';
 import { NotebookEditor } from '../../components/notebook';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ChatWindow } from '../../components/chat';
 import { Table, SupportedConnectionTypes } from '../../../types/backend';
 import useNotebookTabManager from '../../hooks/useNotebookTabManager';
 import {
   useNotebookConnectionState,
   useNotebookSidebarState,
+  useAppContext,
 } from '../../hooks';
 
 const CHAT_MIN_WIDTH = 280;
@@ -105,18 +105,7 @@ const Notebooks = () => {
   const { data: connections = [] } = useGetConnections();
   const { data: duckLakeInstances = [] } = useDuckLakeInstances();
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [notebooksChatOpen, setNotebooksChatOpen] = useState<boolean>(() => {
-    try {
-      return localStorage.getItem('notebooks-chat-open') === 'true';
-    } catch {
-      return false;
-    }
-  });
-
-  useEffect(() => {
-    localStorage.setItem('notebooks-chat-open', String(notebooksChatOpen));
-  }, [notebooksChatOpen]);
+  const { isChatOpen, setIsChatOpen } = useAppContext();
 
   const CHAT_WIDTH_KEY = 'notebooks-chat-width';
   const DEFAULT_CHAT_WIDTH = 360;
@@ -1020,20 +1009,15 @@ const Notebooks = () => {
     >
       <SplitPane
         split="vertical"
-        sizes={['100%', 0]}
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        sizes={isChatOpen && !isNarrow ? verticalSizes : ['100%', 0]}
         onChange={(newSizes) => {
-          // TODO: Re-enable in PR 32
-          /*
-          if (notebooksChatOpen && !isNarrow) {
+          if (isChatOpen && !isNarrow) {
             const chatWidth = newSizes[1] as number;
-            if (chatWidth < CHAT_MIN_WIDTH) {
-              setVerticalSizes(['auto', CHAT_MIN_WIDTH]);
-            } else {
-              setVerticalSizes(newSizes);
-            }
+            setVerticalSizes([
+              'auto',
+              chatWidth < CHAT_MIN_WIDTH ? CHAT_MIN_WIDTH : chatWidth,
+            ]);
           }
-          */
         }}
         sashRender={VerticalSash}
       >
@@ -1102,6 +1086,7 @@ const Notebooks = () => {
                 <Box
                   sx={{
                     flex: 1,
+                    minHeight: 0,
                     display: 'flex',
                     flexDirection: 'column',
                     maxWidth: isSidebarOpen
@@ -1117,6 +1102,7 @@ const Notebooks = () => {
                         // Open the notebook in a new tab
                         notebookTabManager.openNotebook(notebook, connectionId);
                       }}
+                      onSchemaChange={handleRefreshSchema}
                     />
                   ) : (
                     <Box
@@ -1182,28 +1168,28 @@ const Notebooks = () => {
               flexDirection: 'column',
             }}
           >
-            {/* TODO: Re-enable Notebook AI Assistant in PR 32 */}
-            {/* notebooksChatOpen && !isNarrow && (
+            {isChatOpen && !isNarrow && (
               <ChatWindow
+                key={`notebooks-${activeConnectionId}-${notebookTabManager.activeTabId ?? 'none'}`}
                 screenKey="notebooks"
                 connectionId={activeConnectionId ?? undefined}
+                notebookId={notebookTabManager.activeTabId ?? undefined}
                 projectId={
                   selectedProject?.id ? Number(selectedProject.id) : null
                 }
-                onClose={() => setNotebooksChatOpen(false)}
+                onClose={() => setIsChatOpen?.(false)}
               />
-            ) */}
+            )}
           </Box>
         </Pane>
       </SplitPane>
 
       {/* Mobile AI Chat Drawer */}
-      {/* TODO: Re-enable Notebook AI Assistant in PR 32 */}
-      {/* isNarrow && (
+      {isNarrow && (
         <Dialog
           fullScreen
-          open={notebooksChatOpen}
-          onClose={() => setNotebooksChatOpen(false)}
+          open={!!isChatOpen}
+          onClose={() => setIsChatOpen?.(false)}
         >
           <Box
             sx={{
@@ -1213,16 +1199,18 @@ const Notebooks = () => {
             }}
           >
             <ChatWindow
+              key={`notebooks-mobile-${activeConnectionId}-${notebookTabManager.activeTabId ?? 'none'}`}
               screenKey="notebooks"
               connectionId={activeConnectionId ?? undefined}
+              notebookId={notebookTabManager.activeTabId ?? undefined}
               projectId={
                 selectedProject?.id ? Number(selectedProject.id) : null
               }
-              onClose={() => setNotebooksChatOpen(false)}
+              onClose={() => setIsChatOpen?.(false)}
             />
           </Box>
         </Dialog>
-      ) */}
+      )}
 
       {/* Delete Notebook Confirmation Dialog */}
       <Dialog

--- a/src/renderer/services/agent.service.ts
+++ b/src/renderer/services/agent.service.ts
@@ -28,6 +28,7 @@ export interface AgentRunRequest {
   toolMode?: 'chat' | 'agent';
   screenKey?: 'project' | 'sql' | 'notebooks';
   connectionId?: string;
+  notebookId?: string;
 }
 
 /**

--- a/src/renderer/services/chat.service.ts
+++ b/src/renderer/services/chat.service.ts
@@ -17,6 +17,7 @@ class ChatService {
           projectId?: number;
           screenKey?: string;
           connectionId?: string | null;
+          notebookId?: string | null;
         },
   ): Promise<ChatSession[]> {
     const payload = typeof filter === 'number' ? { projectId: filter } : filter;
@@ -40,25 +41,25 @@ class ChatService {
   static async createSession(
     title: string,
     projectId?: number,
-    providerId?: number,
     screenKey?: string,
     connectionId?: string,
+    notebookId?: string,
   ): Promise<ChatSession> {
     const { data } = await client.post<
       {
         title: string;
         projectId?: number;
-        providerId?: number;
         screenKey?: string;
         connectionId?: string;
+        notebookId?: string;
       },
       ChatSession
     >('chat:conversation:create', {
       title,
       projectId,
-      providerId,
       screenKey,
       connectionId,
+      notebookId,
     });
     return data;
   }

--- a/src/renderer/services/notebookBridge.service.ts
+++ b/src/renderer/services/notebookBridge.service.ts
@@ -1,0 +1,240 @@
+export interface NotebookStatePayload {
+  requestId: string;
+  conversationId: number;
+}
+
+export interface CellReadRequestPayload {
+  requestId: string;
+  conversationId: number;
+  cellId: string;
+}
+
+export interface CellUpdateRequestPayload {
+  requestId: string;
+  conversationId: number;
+  cellId: string;
+  content: string;
+}
+
+export interface CellRunRequestPayload {
+  requestId: string;
+  conversationId: number;
+  cellId: string;
+}
+
+export interface CellResultRequestPayload {
+  requestId: string;
+  conversationId: number;
+  cellId: string;
+}
+
+export interface NotebookBridgeHandlers {
+  /** Returns a list of cell summaries (ID, type, preview) */
+  getNotebookState: () => {
+    notebookId: string;
+    notebookName: string;
+    cells: Array<{
+      id: string;
+      type: string;
+      order: number;
+      contentPreview: string;
+      hasOutput: boolean;
+      outputRowCount?: number;
+    }>;
+  };
+  getCellContent: (cellId: string) => string;
+  /** Creates a new cell with the specified content and returns its generated cellId */
+  addCell: (content: string) => string;
+  /** Updates the content of a specific cell (Monaco editor) */
+  setCellContent: (cellId: string, content: string) => void;
+  /** Triggers execution of a cell */
+  runCell: (cellId: string) => void;
+  /** Returns the last execution result of a cell */
+  getCellResult: (cellId: string) => any;
+}
+
+export const registerNotebookBridge = (
+  handlers: NotebookBridgeHandlers,
+): (() => void) => {
+  const onStateRequest = async (...args: unknown[]) => {
+    const payload = args[0] as NotebookStatePayload;
+    try {
+      const state = handlers.getNotebookState();
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:state-response',
+        {
+          requestId: payload.requestId,
+          success: true,
+          ...state,
+        },
+      );
+    } catch (error) {
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:state-response',
+        {
+          requestId: payload.requestId,
+          success: false,
+          error: (error as Error).message,
+        },
+      );
+    }
+  };
+
+  const onCellReadRequest = async (...args: unknown[]) => {
+    const payload = args[0] as CellReadRequestPayload;
+    try {
+      const content = handlers.getCellContent(payload.cellId);
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-read-response',
+        {
+          requestId: payload.requestId,
+          success: true,
+          content,
+        },
+      );
+    } catch (error) {
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-read-response',
+        {
+          requestId: payload.requestId,
+          success: false,
+          error: (error as Error).message,
+        },
+      );
+    }
+  };
+
+  const onCellAddRequest = async (...args: unknown[]) => {
+    const payload = args[0] as { requestId: string; content: string };
+    try {
+      const cellId = handlers.addCell(payload.content);
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-add-response',
+        {
+          requestId: payload.requestId,
+          success: true,
+          cellId,
+        },
+      );
+    } catch (error) {
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-add-response',
+        {
+          requestId: payload.requestId,
+          success: false,
+          error: (error as Error).message,
+        },
+      );
+    }
+  };
+
+  const onCellUpdateRequest = async (...args: unknown[]) => {
+    const payload = args[0] as CellUpdateRequestPayload;
+    try {
+      handlers.setCellContent(payload.cellId, payload.content);
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-update-response',
+        {
+          requestId: payload.requestId,
+          success: true,
+          applied: true,
+        },
+      );
+    } catch (error) {
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-update-response',
+        {
+          requestId: payload.requestId,
+          success: false,
+          applied: false,
+          error: (error as Error).message,
+        },
+      );
+    }
+  };
+
+  const onCellRunRequest = async (...args: unknown[]) => {
+    const payload = args[0] as CellRunRequestPayload;
+    try {
+      handlers.runCell(payload.cellId);
+      // Run request doesn't wait for completion, it just triggers it.
+      // The agent can then poll for results or wait for a push event if we implement one.
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-run-response',
+        {
+          requestId: payload.requestId,
+          success: true,
+        },
+      );
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('[NotebookBridge] Run request failed', error);
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-run-response',
+        {
+          requestId: payload.requestId,
+          success: false,
+          error: (error as Error).message,
+        },
+      );
+    }
+  };
+
+  const onCellResultRequest = async (...args: unknown[]) => {
+    const payload = args[0] as CellResultRequestPayload;
+    try {
+      const result = handlers.getCellResult(payload.cellId);
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-result-response',
+        {
+          requestId: payload.requestId,
+          success: true,
+          result,
+        },
+      );
+    } catch (error) {
+      await window.electron.ipcRenderer.invoke(
+        'agent:notebook:cell-result-response',
+        {
+          requestId: payload.requestId,
+          success: false,
+          error: (error as Error).message,
+        },
+      );
+    }
+  };
+
+  const unsubState = window.electron.ipcRenderer.on(
+    'agent:notebook:state-request',
+    onStateRequest,
+  );
+  const unsubRead = window.electron.ipcRenderer.on(
+    'agent:notebook:cell-read-request',
+    onCellReadRequest,
+  );
+  const unsubAdd = window.electron.ipcRenderer.on(
+    'agent:notebook:cell-add-request',
+    onCellAddRequest,
+  );
+  const unsubUpdate = window.electron.ipcRenderer.on(
+    'agent:notebook:cell-update-request',
+    onCellUpdateRequest,
+  );
+  const unsubRun = window.electron.ipcRenderer.on(
+    'agent:notebook:cell-run-request',
+    onCellRunRequest,
+  );
+  const unsubResult = window.electron.ipcRenderer.on(
+    'agent:notebook:cell-result-request',
+    onCellResultRequest,
+  );
+
+  return () => {
+    if (typeof unsubState === 'function') unsubState();
+    if (typeof unsubRead === 'function') unsubRead();
+    if (typeof unsubAdd === 'function') unsubAdd();
+    if (typeof unsubUpdate === 'function') unsubUpdate();
+    if (typeof unsubRun === 'function') unsubRun();
+    if (typeof unsubResult === 'function') unsubResult();
+  };
+};

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -369,6 +369,18 @@ export type AgentChannels =
   | 'agent:editor:query-results-request' // main → renderer: request snapshot
   | 'agent:editor:query-results-response' // renderer → main: send snapshot back
   | 'agent:editor:query-run-result' // renderer → main: push result after agent-triggered run
+  | 'agent:notebook:state-request' // main → renderer
+  | 'agent:notebook:state-response' // renderer → main
+  | 'agent:notebook:cell-read-request' // main → renderer
+  | 'agent:notebook:cell-read-response' // renderer → main
+  | 'agent:notebook:cell-add-request' // main → renderer
+  | 'agent:notebook:cell-add-response' // renderer → main
+  | 'agent:notebook:cell-update-request' // main → renderer
+  | 'agent:notebook:cell-update-response' // renderer → main
+  | 'agent:notebook:cell-run-request' // main → renderer
+  | 'agent:notebook:cell-run-response' // renderer → main
+  | 'agent:notebook:cell-result-request' // main → renderer
+  | 'agent:notebook:cell-result-response' // renderer → main
   | 'agent:context-usage'
   | 'agent:context-compacted'
   | 'agent:tools:list'


### PR DESCRIPTION
feat(notebooks): integrate AI agent with full notebook-native tool support
This commit implements the complete Notebooks Agent architecture (Plan 32), enabling the AI agent to autonomously read, author, and execute cells within the Notebooks screen.

Key features and architectural updates:
- **Global AI Toggle**: Extended the Main Header Menu to support the AI bot icon on the Notebooks screen, migrating legacy local state to the global `isChatOpen` context.
- **Notebook-Scoped Sessions**: Updated `ChatWindow` to scope chat sessions dynamically by `connectionId` and `notebookId`, ensuring sessions automatically swap or auto-create when changing active tabs or database connections.
- **Renderer Bridge Service**: Implemented `notebookBridge.service.ts` to establish a secure IPC bridge, exposing renderer-side UI functions (read cell, update cell, run cell, fetch result) to the main-process agent.
- **Agent Tools Registration**: Created `notebooks.tools.ts` exposing five new agent tools (`get_state`, `cell_read`, `cell_update`, `cell_run`, `cell_result`) with integrated DML/DDL permission gates and Ask-mode read-only enforcement.
- **System Prompt Enhancement**: Injected a dynamic summary of the active notebook's state directly into the agent's initialization prompt, granting instant context awareness without requiring an initial tool call.
- **Deterministic Pagination**: Hardened backend execution to safely strip explicit `LIMIT` clauses written by the agent, enforcing stable, native server-side pagination for large datasets to prevent UI memory crashes.

This integration unblocks complex, multi-step autonomous data engineering workflows directly within the Notebooks UI.