### PR TITLE
Fix AI SQL Editor crashes on DuckDB connections

### DIFF
--- a/src/main/services/ai/tools/studio/ducklake.tools.ts
+++ b/src/main/services/ai/tools/studio/ducklake.tools.ts
@@ -184,7 +184,9 @@ export function createStudioDuckLakeTools(conversationId: number) {
             schemaCount,
             tableCount,
           };
-          const raw = JSON.stringify(payload);
+          const raw = JSON.stringify(payload, (_, v) =>
+            typeof v === 'bigint' ? v.toString() : v,
+          );
           const output = truncateToolResult(raw, DEFAULT_MAX_OUTPUT_TOKENS);
           const truncated = output !== raw;
 

--- a/src/main/services/ai/tools/studio/sql.tools.ts
+++ b/src/main/services/ai/tools/studio/sql.tools.ts
@@ -163,7 +163,9 @@ function formatQueryResultSummary(snapshot: QueryResultSnapshot): string {
         `Columns: ${snapshot.columns.join(', ')}`,
         '---',
         ...snapshot.rows.map((row, i) => {
-          const s = JSON.stringify(row);
+          const s = JSON.stringify(row, (_, v) =>
+            typeof v === 'bigint' ? v.toString() : v,
+          );
           return `Row ${
             i + 1
           }: ${s.length > 300 ? `${s.slice(0, 297)}...` : s}`;
@@ -319,7 +321,9 @@ export function createStudioSqlTools(conversationId: number) {
             tableCount: filteredTables.length,
           };
 
-          const raw = JSON.stringify(payload);
+          const raw = JSON.stringify(payload, (_, v) =>
+            typeof v === 'bigint' ? v.toString() : v,
+          );
           const output = truncateToolResult(raw, DEFAULT_MAX_OUTPUT_TOKENS);
           const truncated = output !== raw;
 

--- a/src/renderer/components/chat/ToolCallRow.tsx
+++ b/src/renderer/components/chat/ToolCallRow.tsx
@@ -420,7 +420,11 @@ export const ToolCallRow: React.FC<ToolCallRowProps> = ({
           }}
         >
           {hasError && toolCall.error && (
-            <Box sx={{ color: 'error.main', mb: 1 }}>{toolCall.error}</Box>
+            <Box sx={{ color: 'error.main', mb: 1 }}>
+              {typeof toolCall.error === 'string'
+                ? toolCall.error
+                : (toolCall.error as any)?.message || String(toolCall.error)}
+            </Box>
           )}
 
           <Box sx={{ color: 'text.secondary', mb: 0.5, fontWeight: 'bold' }}>


### PR DESCRIPTION
UI: Fixed React crash (Objects are not valid as a React child) in ToolCallRow by correctly extracting the string message from Error objects returned by tool failures.
Backend: Fixed Do not know how to serialize a BigInt error in JSON.stringify within AI SQL tools by adding a replacer to safely convert DuckDB BigInt query results to strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serialization issues with large number values in DuckLake and SQL schema extraction by converting them to strings for safe display.
  * Improved query result summary handling to prevent serialization failures with large numbers.
  * Enhanced error message display in tool call results to handle multiple error formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rosettadb/dbt-studio/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->