### PR TITLE
fix: prevent crash on first-run when database.json is missing optional fields

### DIFF
--- a/src/main/utils/fileHelper.ts
+++ b/src/main/utils/fileHelper.ts
@@ -82,7 +82,16 @@ export const loadDefaultSettings = (): SettingsType => {
 export const loadDatabaseFile = async (): Promise<DataBase> => {
   try {
     const data = await fs.promises.readFile(DB_FILE, 'utf8');
-    return JSON.parse(data);
+    const parsed = JSON.parse(data) as Partial<DataBase>;
+    return {
+      ...parsed,
+      projects: parsed.projects ?? [],
+      settings: parsed.settings ?? loadDefaultSettings(),
+      queries: parsed.queries ?? {},
+      connections: parsed.connections ?? [],
+      sources: parsed.sources ?? [],
+      recentItems: parsed.recentItems ?? [],
+    };
   } catch (error) {
     return {
       projects: [],


### PR DESCRIPTION
Fixes #272 

### How to reproduce

1. Quit the app.
2. Delete `database.json` from the application data directory:

   * **macOS:** `~/Library/Application Support/rosetta-dbt-studio/database.json`
   * **Windows:** `%APPDATA%\rosetta-dbt-studio\database.json` (e.g. `C:\Users\<you>\AppData\Roaming\rosetta-dbt-studio\database.json`)
   * **Linux:** `~/.config/rosetta-dbt-studio/database.json`
3. Launch the app.
4. Create a new project, import a folder, or clone a GitHub repository.

### Result before this fix

The operation fails with:

```text
Cannot read properties of undefined (reading 'find')
```

### Result after this fix

The project is created successfully, and `database.json` is initialized with the complete schema (`connections`, `sources`, `recentItems`, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database file loading to ensure all necessary fields are properly initialized with default values, preventing potential issues when loading incomplete or corrupted database files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->