### PR TITLE
fix(setup): First lunch ipc handlers not working

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -270,9 +270,8 @@ if (!gotTheLock) {
 }
 
 ipcMain.handle('windows:closeSetup', () => {
-  if (windowManager) {
-    windowManager.closeSetupWindow();
-  }
+  app.relaunch();
+  app.exit(0);
 });
 
 // Cleanup DuckLake connections before app quits

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -271,7 +271,7 @@ if (!gotTheLock) {
 
 ipcMain.handle('windows:closeSetup', () => {
   app.relaunch();
-  app.exit(0);
+  app.quit();
 });
 
 // Cleanup DuckLake connections before app quits

--- a/src/renderer/screens/setup/index.tsx
+++ b/src/renderer/screens/setup/index.tsx
@@ -20,7 +20,7 @@ const ADAPTERS = [
 
 const Setup: React.FC = () => {
   const { data: settings, isLoading } = useGetSettings();
-  const { mutate: updateSettings } = useUpdateSettings();
+  const { mutateAsync: updateSettings } = useUpdateSettings();
   const [isInitialized, setIsInitialized] = React.useState(false);
   const [currentStep, setCurrentStep] = React.useState<number>(0);
   const [selectedAdapters, setSelectedAdapters] = React.useState<string[]>(
@@ -34,7 +34,9 @@ const Setup: React.FC = () => {
   };
 
   const handleSkip = async () => {
-    saveSetting('isSetup', 'true');
+    if (settings) {
+      await updateSettings({ ...settings, isSetup: 'true' });
+    }
     await client.get('windows:closeSetup');
   };
 


### PR DESCRIPTION
Modify the windows:closeSetup IPC handler to relaunch and exit the app instead of closing the setup window directly. In the setup screen, switch to using mutateAsync for settings updates, add an existence check for settings, and await the async call in handleSkip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup window closure to ensure proper application restart after configuration.
  * Fixed skip setup action to ensure settings are properly saved before closing the setup screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->