### PR TITLE
fixed: cloning project causing missing path error when the setting is

### DIFF
--- a/src/main/services/settings.service.ts
+++ b/src/main/services/settings.service.ts
@@ -56,6 +56,12 @@ export default class SettingsService {
     return {
       ...defaultSettings,
       ...dataBase.settings,
+      projectsDirectory:
+        dataBase.settings.projectsDirectory ||
+        defaultSettings.projectsDirectory,
+      sampleRosettaMainConf:
+        dataBase.settings.sampleRosettaMainConf ||
+        defaultSettings.sampleRosettaMainConf,
     };
   }
 


### PR DESCRIPTION
Cloning project on situations where "Projects directory path" in settings is not set would fail.
Same applied for "Get Started" project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced settings loading to guarantee critical configuration values are always available with appropriate fallbacks, improving application stability and preventing configuration-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->