### PR TITLE
enhance:git ssh passphrase

### DIFF
--- a/src/main/services/git.service.ts
+++ b/src/main/services/git.service.ts
@@ -2,6 +2,7 @@
 import simpleGit, { SimpleGit } from 'simple-git';
 import path from 'path';
 import fs from 'fs';
+import os from 'os';
 import { AuthError } from '../errors';
 import {
   FileStatus,
@@ -43,6 +44,21 @@ function getRepoNameFromUrl(url: string): string {
   }
 
   return clean;
+}
+
+function isSshUrl(url: string): boolean {
+  return url.startsWith('git@') || url.startsWith('ssh://');
+}
+
+async function getOrCreateAskpassScript(): Promise<string> {
+  const isWindows = process.platform === 'win32';
+  const ext = isWindows ? '.bat' : '.sh';
+  const scriptPath = path.join(os.tmpdir(), `rosetta-git-askpass${ext}`);
+  const content = isWindows
+    ? '@echo off\r\necho %GIT_PASSPHRASE%\r\n'
+    : '#!/bin/sh\necho "$GIT_PASSPHRASE"\n';
+  await fs.promises.writeFile(scriptPath, content, { mode: 0o700 });
+  return scriptPath;
 }
 
 function injectCredentialsIntoRemoteUrl(
@@ -712,11 +728,24 @@ export default class GitService {
     try {
       let urlToUse = remoteUrl;
 
-      if (credentials) {
-        urlToUse = injectCredentialsIntoRemoteUrl(remoteUrl, credentials);
+      if (credentials?.sshPassphrase && isSshUrl(remoteUrl)) {
+        const askpassScript = await getOrCreateAskpassScript();
+        await git
+          .env({
+            ...process.env,
+            SSH_ASKPASS: askpassScript,
+            SSH_ASKPASS_REQUIRE: 'force',
+            GIT_PASSPHRASE: credentials.sshPassphrase,
+            GIT_TERMINAL_PROMPT: '0',
+            DISPLAY: process.env.DISPLAY || 'dummy',
+          })
+          .clone(urlToUse, destinationPath);
+      } else {
+        if (credentials && !isSshUrl(remoteUrl)) {
+          urlToUse = injectCredentialsIntoRemoteUrl(remoteUrl, credentials);
+        }
+        await git.clone(urlToUse, destinationPath);
       }
-
-      await git.clone(urlToUse, destinationPath);
 
       // Remove .git directory if requested (for external repos that users want to make their own)
       if (removeGit) {

--- a/src/renderer/components/modals/cloneRepoModal/index.tsx
+++ b/src/renderer/components/modals/cloneRepoModal/index.tsx
@@ -20,6 +20,10 @@ type Props = {
   successCallback?: (project?: any) => void;
 };
 
+function isSshUrl(url: string): boolean {
+  return url.startsWith('git@') || url.startsWith('ssh://');
+}
+
 export const CloneRepoModal: React.FC<Props> = ({
   isOpen,
   onClose,
@@ -29,6 +33,10 @@ export const CloneRepoModal: React.FC<Props> = ({
   const [url, setUrl] = React.useState('');
   const [loading, setLoading] = React.useState(false);
   const [removeGit, setRemoveGit] = React.useState(false);
+  const [sshPassphrase, setSshPassphrase] = React.useState('');
+
+  const isSSH = isSshUrl(url);
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Clone Repo">
       <StyledForm
@@ -36,8 +44,13 @@ export const CloneRepoModal: React.FC<Props> = ({
           event.preventDefault();
           setLoading(true);
           try {
+            const credentials =
+              isSSH && sshPassphrase
+                ? { username: '', password: '', sshPassphrase }
+                : undefined;
+
             const { error, authRequired, path, name, connectionId } =
-              await gitServices.gitClone(url, undefined, removeGit);
+              await gitServices.gitClone(url, credentials, removeGit);
 
             if (error) {
               toast.error(error);
@@ -49,7 +62,6 @@ export const CloneRepoModal: React.FC<Props> = ({
               setLoading(false);
               return;
             }
-
             if (!path || !name) {
               toast.error('Something went wrong!');
               setLoading(false);
@@ -76,12 +88,27 @@ export const CloneRepoModal: React.FC<Props> = ({
           <TextField
             variant="outlined"
             placeholder="Enter repository URL (e.g., https://github.com/user/repo.git)"
-            onChange={(event) => setUrl(event.target.value)}
+            onChange={(event) => {
+              setUrl(event.target.value);
+              setSshPassphrase('');
+            }}
             value={url}
             fullWidth
             autoFocus
             disabled={loading}
           />
+          {isSSH && (
+            <TextField
+              variant="outlined"
+              type="password"
+              label="SSH Key Passphrase"
+              placeholder="Leave empty if key has no passphrase"
+              onChange={(event) => setSshPassphrase(event.target.value)}
+              value={sshPassphrase}
+              fullWidth
+              disabled={loading}
+            />
+          )}
           <Tooltip
             title="Check this if you're cloning an external repository that you want to make your own. This removes the original .git history so you can initialize your own repository."
             placement="top"

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -515,6 +515,7 @@ export type EnhanceModelResponseType = {
 export type GitCredentials = {
   username: string;
   password: string;
+  sshPassphrase?: string;
 };
 
 export type GitBranch = {


### PR DESCRIPTION
added: support for passphrase when git is used via ssh and key has
password

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cloning repositories over SSH with an optional passphrase.
  * The clone dialog now shows an additional passphrase field when an SSH URL is entered.

* **Bug Fixes**
  * Improved credential handling so username/password are only applied when appropriate for non-SSH remotes.
  * SSH cloning now runs non-interactively to better support passphrase entry during cloning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->