### PR TITLE
fixed: extracting name from file path failing on windows due to

### DIFF
--- a/src/renderer/helpers/utils.ts
+++ b/src/renderer/helpers/utils.ts
@@ -282,16 +282,15 @@ export const getConnectionInput = (conn: ConnectionModel) => {
 export const extractModelNameFromPath = (filePath: string): string => {
   // Extract model name from file path
   // Example: /path/to/project/models/staging/my_model.sql -> staging.my_model
-  const pathParts = filePath.split('/');
+  const sep = filePath.includes('\\') ? '\\' : '/';
+  const pathParts = filePath.split(sep);
   const modelsIndex = pathParts.findIndex((part) => part === 'models');
   if (modelsIndex === -1) return '';
 
-  // Get the path after 'models/' and before '.sql'
-  const modelPath = pathParts.slice(modelsIndex + 1).join('/');
+  const modelPath = pathParts.slice(modelsIndex + 1).join(sep);
   const modelName = modelPath.replace('.sql', '');
 
-  // Convert path separators to dots for dbt selection
-  return modelName.replace(/\//g, '.');
+  return modelName.replace(new RegExp(`\\${sep}`, 'g'), '.');
 };
 
 /**

--- a/tests/unit/renderer/helpers/utils.test.ts
+++ b/tests/unit/renderer/helpers/utils.test.ts
@@ -121,6 +121,12 @@ describe('renderer/helpers/utils', () => {
     it('should return empty string when models folder missing', () => {
       expect(extractModelNameFromPath('/p/staging/my_model.sql')).toBe('');
     });
+
+    it('should handle Windows-style paths with backslashes', () => {
+      expect(
+        extractModelNameFromPath('C:\\p\\models\\staging\\my_model.sql'),
+      ).toBe('staging.my_model');
+    });
   });
 
   describe('getFileExtension / isEditableFile / getNonEditableFileMessage', () => {


### PR DESCRIPTION
incorrect path handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling so model names are parsed correctly from both Windows and Unix-style file paths.
  * Ensured model paths are consistently converted into dot notation after removing the file extension.
* **Tests**
  * Added coverage for Windows-style paths to confirm model name parsing works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->