### PR TITLE
fix(cloud-explorer): preserve real folder modified timestamps

### DIFF
--- a/src/main/services/cloudExplorer.service.ts
+++ b/src/main/services/cloudExplorer.service.ts
@@ -6,6 +6,7 @@ import {
   ListObjectsV2Command,
   ListObjectsCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   PutObjectCommand,
   CreateMultipartUploadCommand,
   UploadPartCommand,
@@ -62,6 +63,32 @@ import {
 
 // Cloud storage service class
 class CloudExplorerService {
+  private static async withS3FolderMarkerDates(
+    client: S3Client,
+    bucketName: string,
+    folders: StorageObject[],
+  ): Promise<StorageObject[]> {
+    return Promise.all(
+      folders.map(async (folder) => {
+        try {
+          const result = await client.send(
+            new HeadObjectCommand({
+              Bucket: bucketName,
+              Key: folder.name,
+            }),
+          );
+
+          return {
+            ...folder,
+            updated: result.LastModified,
+          };
+        } catch {
+          return folder;
+        }
+      }),
+    );
+  }
+
   // AWS S3 Methods
   private static createS3Client(config: S3Config): S3Client {
     // Validate credentials are provided
@@ -122,12 +149,15 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = (result.CommonPrefixes || []).map((folderPrefix) => ({
-        name: folderPrefix.Prefix!,
-        size: 0,
-        updated: new Date(),
-        isDirectory: true,
-      }));
+      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+        client,
+        bucketName,
+        (result.CommonPrefixes || []).map((folderPrefix) => ({
+          name: folderPrefix.Prefix!,
+          size: 0,
+          isDirectory: true,
+        })),
+      );
 
       const files = (result.Contents || [])
         .filter((obj) => obj.Key !== prefix)
@@ -301,7 +331,6 @@ class CloudExplorerService {
         result.push({
           name: blobPrefix.name,
           size: 0,
-          updated: new Date(),
           isDirectory: true,
         });
       });
@@ -483,7 +512,6 @@ class CloudExplorerService {
       const directoryObjects = prefixes.map((folderPrefix: string) => ({
         name: folderPrefix,
         size: 0,
-        updated: new Date(),
         isDirectory: true,
       }));
 
@@ -614,12 +642,15 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = (result.CommonPrefixes || []).map((folderPrefix) => ({
-        name: folderPrefix.Prefix!,
-        size: 0,
-        updated: new Date(),
-        isDirectory: true,
-      }));
+      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+        client,
+        bucketName,
+        (result.CommonPrefixes || []).map((folderPrefix) => ({
+          name: folderPrefix.Prefix!,
+          size: 0,
+          isDirectory: true,
+        })),
+      );
 
       const files = (result.Contents || [])
         .filter((obj) => obj.Key !== prefix)
@@ -796,12 +827,15 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = (result.CommonPrefixes || []).map((folderPrefix) => ({
-        name: folderPrefix.Prefix!,
-        size: 0,
-        updated: new Date(),
-        isDirectory: true,
-      }));
+      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+        client,
+        bucketName,
+        (result.CommonPrefixes || []).map((folderPrefix) => ({
+          name: folderPrefix.Prefix!,
+          size: 0,
+          isDirectory: true,
+        })),
+      );
 
       const files = (result.Contents || [])
         .filter((obj) => obj.Key !== prefix)
@@ -991,7 +1025,6 @@ class CloudExplorerService {
             objects.push({
               name: cp.Prefix,
               size: 0,
-              updated: new Date(),
               isDirectory: true,
             });
           }
@@ -1013,8 +1046,18 @@ class CloudExplorerService {
         });
       }
 
+      const folders = objects.filter((object) => object.isDirectory);
+      const files = objects.filter((object) => !object.isDirectory);
+
       return {
-        objects,
+        objects: [
+          ...(await CloudExplorerService.withS3FolderMarkerDates(
+            client,
+            bucketName,
+            folders,
+          )),
+          ...files,
+        ],
         nextPageToken: response.NextContinuationToken,
       };
     } catch (error) {
@@ -1178,12 +1221,15 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = (result.CommonPrefixes || []).map((folderPrefix) => ({
-        name: folderPrefix.Prefix!,
-        size: 0,
-        updated: new Date(),
-        isDirectory: true,
-      }));
+      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+        client,
+        bucketName,
+        (result.CommonPrefixes || []).map((folderPrefix) => ({
+          name: folderPrefix.Prefix!,
+          size: 0,
+          isDirectory: true,
+        })),
+      );
 
       const files = (result.Contents || [])
         .filter((obj) => obj.Key !== prefix)
@@ -1364,12 +1410,15 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = (result.CommonPrefixes || []).map((folderPrefix) => ({
-        name: folderPrefix.Prefix!,
-        size: 0,
-        updated: new Date(),
-        isDirectory: true,
-      }));
+      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+        client,
+        bucketName,
+        (result.CommonPrefixes || []).map((folderPrefix) => ({
+          name: folderPrefix.Prefix!,
+          size: 0,
+          isDirectory: true,
+        })),
+      );
 
       const files = (result.Contents || [])
         .filter((obj) => obj.Key !== prefix)

--- a/src/main/services/cloudExplorer.service.ts
+++ b/src/main/services/cloudExplorer.service.ts
@@ -6,7 +6,6 @@ import {
   ListObjectsV2Command,
   ListObjectsCommand,
   GetObjectCommand,
-  HeadObjectCommand,
   PutObjectCommand,
   CreateMultipartUploadCommand,
   UploadPartCommand,
@@ -63,7 +62,7 @@ import {
 
 // Cloud storage service class
 class CloudExplorerService {
-  private static async withS3FolderMarkerDates(
+  private static async withS3FolderMetadata(
     client: S3Client,
     bucketName: string,
     folders: StorageObject[],
@@ -71,16 +70,41 @@ class CloudExplorerService {
     return Promise.all(
       folders.map(async (folder) => {
         try {
-          const result = await client.send(
-            new HeadObjectCommand({
-              Bucket: bucketName,
-              Key: folder.name,
-            }),
-          );
+          let continuationToken: string | undefined;
+          let latestModified: Date | undefined;
+          let totalSize = 0;
+
+          do {
+            // eslint-disable-next-line no-await-in-loop
+            const result = await client.send(
+              new ListObjectsV2Command({
+                Bucket: bucketName,
+                Prefix: folder.name,
+                ContinuationToken: continuationToken,
+                MaxKeys: 1000,
+              }),
+            );
+
+            (result.Contents || []).forEach((object) => {
+              totalSize += object.Size || 0;
+
+              if (
+                object.LastModified &&
+                (!latestModified || object.LastModified > latestModified)
+              ) {
+                latestModified = object.LastModified;
+              }
+            });
+
+            continuationToken = result.IsTruncated
+              ? result.NextContinuationToken
+              : undefined;
+          } while (continuationToken);
 
           return {
             ...folder,
-            updated: result.LastModified,
+            size: totalSize,
+            updated: latestModified,
           };
         } catch {
           return folder;
@@ -149,7 +173,7 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+      const folders = await CloudExplorerService.withS3FolderMetadata(
         client,
         bucketName,
         (result.CommonPrefixes || []).map((folderPrefix) => ({
@@ -642,7 +666,7 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+      const folders = await CloudExplorerService.withS3FolderMetadata(
         client,
         bucketName,
         (result.CommonPrefixes || []).map((folderPrefix) => ({
@@ -827,7 +851,7 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+      const folders = await CloudExplorerService.withS3FolderMetadata(
         client,
         bucketName,
         (result.CommonPrefixes || []).map((folderPrefix) => ({
@@ -1051,7 +1075,7 @@ class CloudExplorerService {
 
       return {
         objects: [
-          ...(await CloudExplorerService.withS3FolderMarkerDates(
+          ...(await CloudExplorerService.withS3FolderMetadata(
             client,
             bucketName,
             folders,
@@ -1221,7 +1245,7 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+      const folders = await CloudExplorerService.withS3FolderMetadata(
         client,
         bucketName,
         (result.CommonPrefixes || []).map((folderPrefix) => ({
@@ -1410,7 +1434,7 @@ class CloudExplorerService {
         }),
       );
 
-      const folders = await CloudExplorerService.withS3FolderMarkerDates(
+      const folders = await CloudExplorerService.withS3FolderMetadata(
         client,
         bucketName,
         (result.CommonPrefixes || []).map((folderPrefix) => ({

--- a/src/main/services/cloudExplorer.service.ts
+++ b/src/main/services/cloudExplorer.service.ts
@@ -85,7 +85,8 @@ class CloudExplorerService {
               }),
             );
 
-            (result.Contents || []).forEach((object) => {
+            // eslint-disable-next-line no-restricted-syntax
+            for (const object of result.Contents || []) {
               totalSize += object.Size || 0;
 
               if (
@@ -94,7 +95,7 @@ class CloudExplorerService {
               ) {
                 latestModified = object.LastModified;
               }
-            });
+            }
 
             continuationToken = result.IsTruncated
               ? result.NextContinuationToken

--- a/src/renderer/components/cloudExplorer/ExplorerBucketContent.tsx
+++ b/src/renderer/components/cloudExplorer/ExplorerBucketContent.tsx
@@ -554,7 +554,7 @@ export const ExplorerBucketContent: React.FC<ExplorerBucketContentProps> = ({
                   </Box>
                 </TableCell>
                 <TableCell align="right">
-                  {object.isDirectory
+                  {object.isDirectory && object.size === 0
                     ? '-'
                     : formatFileSize(object.size, {
                         showZeroAsNA: false,

--- a/src/types/frontend.ts
+++ b/src/types/frontend.ts
@@ -101,7 +101,7 @@ export interface Bucket {
 export interface StorageObject {
   name: string;
   size: number;
-  updated: Date;
+  updated?: Date;
   contentType?: string;
   isDirectory: boolean;
 }


### PR DESCRIPTION
Use S3 HeadObject calls to read the LastModified value from folder marker objects instead of assigning folders the current time during listing.

Also allow folder timestamps to be absent when the provider only returns a virtual prefix, so the UI shows "-" rather than "less than a minute ago".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Folder and prefix items in cloud storage listings now show a more accurate last-updated time when available.
  * If a folder timestamp can’t be determined, it may now appear without an updated date instead of showing a misleading default value.
  * Improved consistency across multiple storage providers, including AWS-compatible services, Azure Blob, and Google Cloud Storage.

* **Changes**
  * Updated item details to allow missing updated timestamps for folder-like entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->