### PR TITLE
update: keystore - changed environment '+' button to include text and

### DIFF
--- a/src/renderer/components/settings/KeystoreSettings.tsx
+++ b/src/renderer/components/settings/KeystoreSettings.tsx
@@ -273,15 +273,15 @@ export const KeystoreSettings: React.FC = () => {
             />
           ))}
         </Tabs>
-        <Tooltip title="Add environment">
-          <IconButton
-            size="small"
-            onClick={() => setAddEnvOpen(true)}
-            sx={{ ml: 1 }}
-          >
-            <Add fontSize="small" />
-          </IconButton>
-        </Tooltip>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<Add />}
+          onClick={() => setAddEnvOpen(true)}
+          sx={{ ml: 1, whiteSpace: 'nowrap' }}
+        >
+          New environment
+        </Button>
       </Box>
 
       <Card


### PR DESCRIPTION
match rest of settings design

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the environment tab to use a clearer **“New environment”** button with an add icon.
  * The action still opens the **New Environment** dialog, but is now more discoverable and user-friendly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->