### PR TITLE
added: git ssh pass dialog on commit

### DIFF
--- a/src/main/services/git.service.ts
+++ b/src/main/services/git.service.ts
@@ -748,20 +748,20 @@ export default class GitService {
     try {
       let urlToUse = remoteUrl;
 
-      if (credentials?.sshPassphrase && isSshUrl(remoteUrl)) {
+      if (isSshUrl(remoteUrl)) {
         const askpassScript = await getOrCreateAskpassScript();
         await git
           .env({
             ...process.env,
             SSH_ASKPASS: askpassScript,
             SSH_ASKPASS_REQUIRE: 'force',
-            GIT_PASSPHRASE: credentials.sshPassphrase,
+            GIT_PASSPHRASE: credentials?.sshPassphrase ?? '',
             GIT_TERMINAL_PROMPT: '0',
             DISPLAY: process.env.DISPLAY || 'dummy',
           })
           .clone(urlToUse, destinationPath);
       } else {
-        if (credentials && !isSshUrl(remoteUrl)) {
+        if (credentials) {
           urlToUse = injectCredentialsIntoRemoteUrl(remoteUrl, credentials);
         }
         await git.clone(urlToUse, destinationPath);
@@ -806,6 +806,16 @@ export default class GitService {
         connectionId,
       };
     } catch (err: any) {
+      // Clean up the created directory if clone fails
+      try {
+        if (fs.existsSync(destinationPath)) {
+          await fs.promises.rm(destinationPath, { recursive: true, force: true });
+        }
+      } catch (cleanupErr) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to clean up directory after failed clone:', cleanupErr);
+      }
+
       if (isAuthError(err)) throw new AuthError();
       throw new Error(`Clone failed: ${err.message}`);
     }

--- a/src/main/services/git.service.ts
+++ b/src/main/services/git.service.ts
@@ -809,11 +809,17 @@ export default class GitService {
       // Clean up the created directory if clone fails
       try {
         if (fs.existsSync(destinationPath)) {
-          await fs.promises.rm(destinationPath, { recursive: true, force: true });
+          await fs.promises.rm(destinationPath, {
+            recursive: true,
+            force: true,
+          });
         }
       } catch (cleanupErr) {
         // eslint-disable-next-line no-console
-        console.error('Failed to clean up directory after failed clone:', cleanupErr);
+        console.error(
+          'Failed to clean up directory after failed clone:',
+          cleanupErr,
+        );
       }
 
       if (isAuthError(err)) throw new AuthError();

--- a/src/main/services/git.service.ts
+++ b/src/main/services/git.service.ts
@@ -652,10 +652,7 @@ export default class GitService {
     );
   }
 
-  async push(
-    repoPath: string,
-    credentials?: { username: string; password: string },
-  ) {
+  async push(repoPath: string, credentials?: GitCredentials) {
     const git = this.getGitInstance(repoPath);
 
     try {
@@ -667,11 +664,32 @@ export default class GitService {
 
       const branchSummary = await git.branch();
       const currentBranch = branchSummary.current;
-      const remoteWithAuth = credentials
-        ? injectCredentialsIntoRemoteUrl(origin.refs.push, credentials)
-        : origin.refs.push;
 
-      await git.remote(['set-url', 'origin', remoteWithAuth]);
+      const isSsh = isSshUrl(origin.refs.push);
+
+      const remoteWithAuth =
+        credentials && !isSsh
+          ? injectCredentialsIntoRemoteUrl(origin.refs.push, credentials)
+          : origin.refs.push;
+
+      if (remoteWithAuth !== origin.refs.push) {
+        await git.remote(['set-url', 'origin', remoteWithAuth]);
+      }
+
+      // For SSH remotes, terminal prompting must always be disabled, even when
+      // no passphrase has been supplied yet. Otherwise ssh opens /dev/tty
+      // directly and blocks waiting for input on the process's controlling
+      // terminal instead of failing back into an authRequired response.
+      const gitForPush = isSsh
+        ? git.env({
+            ...process.env,
+            SSH_ASKPASS: await getOrCreateAskpassScript(),
+            SSH_ASKPASS_REQUIRE: 'force',
+            GIT_PASSPHRASE: credentials?.sshPassphrase ?? '',
+            GIT_TERMINAL_PROMPT: '0',
+            DISPLAY: process.env.DISPLAY || 'dummy',
+          })
+        : git;
 
       // Check if tracking is set before pushing
       const isTracking = await this.isTrackingSet(repoPath);
@@ -679,9 +697,9 @@ export default class GitService {
       try {
         // Always use -u flag if tracking is not set to ensure upstream is configured
         if (!isTracking) {
-          await git.push(['-u', 'origin', currentBranch]);
+          await gitForPush.push(['-u', 'origin', currentBranch]);
         } else {
-          await git.push('origin', currentBranch);
+          await gitForPush.push('origin', currentBranch);
         }
       } catch (err: any) {
         const msg = err.message?.toLowerCase() ?? '';
@@ -693,13 +711,15 @@ export default class GitService {
           msg.includes('has no upstream');
 
         if (shouldTryUpstreamPush) {
-          await git.push(['-u', 'origin', currentBranch]);
+          await gitForPush.push(['-u', 'origin', currentBranch]);
         } else {
           throw err;
         }
       }
 
-      await git.remote(['set-url', 'origin', origin.refs.push]);
+      if (remoteWithAuth !== origin.refs.push) {
+        await git.remote(['set-url', 'origin', origin.refs.push]);
+      }
 
       return { success: true };
     } catch (err) {

--- a/src/renderer/components/modals/index.ts
+++ b/src/renderer/components/modals/index.ts
@@ -17,3 +17,4 @@ export * from './pushToCloudModal';
 export * from './rawLayerModal';
 export * from './removeConnectionModal';
 export * from './pipelineSelectorModal';
+export * from './sshPassphraseModal';

--- a/src/renderer/components/modals/sshPassphraseModal/index.tsx
+++ b/src/renderer/components/modals/sshPassphraseModal/index.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Box,
+} from '@mui/material';
+import { Close, Check } from '@mui/icons-material';
+
+type Props = {
+  isOpen: boolean;
+  isLoading?: boolean;
+  onClose: () => void;
+  onSubmit: (passphrase: string) => void;
+};
+
+export const SshPassphraseModal: React.FC<Props> = ({
+  isOpen,
+  isLoading = false,
+  onClose,
+  onSubmit,
+}) => {
+  const [passphrase, setPassphrase] = React.useState('');
+
+  React.useEffect(() => {
+    if (isOpen) {
+      setPassphrase('');
+    }
+  }, [isOpen]);
+
+  const handleSubmit = () => {
+    onSubmit(passphrase);
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      maxWidth="xs"
+      fullWidth
+      aria-labelledby="ssh-passphrase-dialog-title"
+    >
+      <DialogTitle id="ssh-passphrase-dialog-title">
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          SSH Key Passphrase
+          <IconButton
+            aria-label="close"
+            onClick={onClose}
+            sx={{
+              color: 'text.secondary',
+              '&:hover': {
+                backgroundColor: 'action.hover',
+              },
+            }}
+          >
+            <Close fontSize="small" />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>
+          The remote requires authentication. Enter your SSH key passphrase to
+          continue.
+        </DialogContentText>
+        <TextField
+          autoFocus
+          variant="outlined"
+          type="password"
+          label="SSH Key Passphrase"
+          placeholder="Leave empty if key has no passphrase"
+          value={passphrase}
+          onChange={(e) => setPassphrase(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+          fullWidth
+          disabled={isLoading}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={onClose}
+          color="secondary"
+          variant="outlined"
+          disabled={isLoading}
+          startIcon={<Close fontSize="small" />}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          color="primary"
+          variant="contained"
+          disabled={isLoading}
+          startIcon={<Check fontSize="small" />}
+        >
+          {isLoading ? 'Pushing...' : 'Continue'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/renderer/components/sourceControl/RepositoryHeader.tsx
+++ b/src/renderer/components/sourceControl/RepositoryHeader.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import { MoreHoriz, Sync } from '@mui/icons-material';
 import { useQueryClient } from 'react-query';
+import { toast } from 'react-toastify';
 import {
   useGitPull,
   useGitPush,
@@ -25,7 +26,11 @@ import { BranchDialog } from './BranchDialog';
 import { Icon } from '../icon';
 import { icons } from '../../../../assets';
 import { QUERY_KEYS } from '../../config/constants';
-import { GitUiError } from '../modals';
+import { GitUiError, SshPassphraseModal } from '../modals';
+
+function isSshUrl(url: string): boolean {
+  return url.startsWith('git@') || url.startsWith('ssh://');
+}
 
 interface RepositoryHeaderProps {
   projectPath?: string;
@@ -97,9 +102,28 @@ export const RepositoryHeader: React.FC<RepositoryHeaderProps> = ({
     },
   });
 
+  const [sshPassphraseDialogOpen, setSshPassphraseDialogOpen] = useState(false);
+  const [sshPassphraseAttempted, setSshPassphraseAttempted] = useState(false);
+
+  // Close any pending SSH prompt from a previous project — this component
+  // stays mounted across project switches, only projectPath changes.
+  React.useEffect(() => {
+    setSshPassphraseDialogOpen(false);
+    setSshPassphraseAttempted(false);
+  }, [projectPath]);
+
   const { mutate: push, isLoading: isPushing } = useGitPush({
     onSuccess: (data) => {
       if (data?.authRequired) {
+        const originPushUrl = remotes.find((r) => r.name === 'origin')?.refs
+          .push;
+        if (originPushUrl && isSshUrl(originPushUrl)) {
+          if (sshPassphraseAttempted) {
+            toast.error('Incorrect SSH key passphrase. Please try again.');
+          }
+          setSshPassphraseDialogOpen(true);
+          return;
+        }
         emitGitError({
           title: 'Authentication required',
           message:
@@ -119,6 +143,8 @@ export const RepositoryHeader: React.FC<RepositoryHeaderProps> = ({
         });
         return;
       }
+      setSshPassphraseDialogOpen(false);
+      setSshPassphraseAttempted(false);
       onSynchronize?.();
     },
     onError: (error) => {
@@ -130,6 +156,20 @@ export const RepositoryHeader: React.FC<RepositoryHeaderProps> = ({
       });
     },
   });
+
+  const handleSshPassphraseSubmit = (sshPassphrase: string) => {
+    if (!projectPath) return;
+    setSshPassphraseAttempted(true);
+    push({
+      path: projectPath,
+      credentials: { username: '', password: '', sshPassphrase },
+    });
+  };
+
+  const handleSshPassphraseCancel = () => {
+    setSshPassphraseDialogOpen(false);
+    setSshPassphraseAttempted(false);
+  };
 
   // Branch operation state
   const [branchDialogOpen, setBranchDialogOpen] = useState(false);
@@ -524,6 +564,14 @@ export const RepositoryHeader: React.FC<RepositoryHeaderProps> = ({
           }}
           isLoading={isCreating || isDeleting || isRenaming || isSwitching}
           branches={branches}
+        />
+
+        {/* SSH Passphrase Dialog */}
+        <SshPassphraseModal
+          isOpen={sshPassphraseDialogOpen}
+          isLoading={isPushing}
+          onClose={handleSshPassphraseCancel}
+          onSubmit={handleSshPassphraseSubmit}
         />
       </Box>
     </Box>

--- a/src/renderer/components/sourceControl/TipTapCommitInput.tsx
+++ b/src/renderer/components/sourceControl/TipTapCommitInput.tsx
@@ -1,13 +1,18 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Box, Button, CircularProgress, useTheme } from '@mui/material';
 import { Check, Sync, ArrowUpward } from '@mui/icons-material';
+import { toast } from 'react-toastify';
 import {
   useGitCommit,
   useGetAheadBehindCount,
   useGitPush,
   useGetRemotes,
 } from '../../controllers';
-import { AddGitRemoteModal, GitUiError } from '../modals';
+import { AddGitRemoteModal, GitUiError, SshPassphraseModal } from '../modals';
+
+function isSshUrl(url: string): boolean {
+  return url.startsWith('git@') || url.startsWith('ssh://');
+}
 
 interface TipTapCommitInputProps {
   projectPath?: string;
@@ -67,10 +72,37 @@ export const TipTapCommitInput: React.FC<TipTapCommitInputProps> = ({
     },
   });
 
+  const {
+    data: remotes = [],
+    refetch: refetchRemotes,
+    isLoading: isRemotesLoading,
+  } = useGetRemotes(projectPath || '', {
+    enabled: !!projectPath,
+  });
+
+  const [sshPassphraseDialogOpen, setSshPassphraseDialogOpen] = useState(false);
+  const [sshPassphraseAttempted, setSshPassphraseAttempted] = useState(false);
+
+  // Close any pending SSH prompt from a previous project — this component
+  // stays mounted across project switches, only projectPath changes.
+  useEffect(() => {
+    setSshPassphraseDialogOpen(false);
+    setSshPassphraseAttempted(false);
+  }, [projectPath]);
+
   const { mutate: pushFiles, isLoading: isPushing } = useGitPush({
     onSuccess: (data) => {
       setPendingAction(null);
       if (data?.authRequired) {
+        const originPushUrl = remotes.find((r) => r.name === 'origin')?.refs
+          .push;
+        if (originPushUrl && isSshUrl(originPushUrl)) {
+          if (sshPassphraseAttempted) {
+            toast.error('Incorrect SSH key passphrase. Please try again.');
+          }
+          setSshPassphraseDialogOpen(true);
+          return;
+        }
         onGitError?.({
           title: 'Authentication required',
           message:
@@ -90,6 +122,8 @@ export const TipTapCommitInput: React.FC<TipTapCommitInputProps> = ({
         });
         return;
       }
+      setSshPassphraseDialogOpen(false);
+      setSshPassphraseAttempted(false);
       refetchAheadBehind();
       onCommitSuccess?.();
     },
@@ -102,14 +136,6 @@ export const TipTapCommitInput: React.FC<TipTapCommitInputProps> = ({
         repoPath: projectPath,
       });
     },
-  });
-
-  const {
-    data: remotes = [],
-    refetch: refetchRemotes,
-    isLoading: isRemotesLoading,
-  } = useGetRemotes(projectPath || '', {
-    enabled: !!projectPath,
   });
 
   const [isAddRemoteModalOpen, setIsAddRemoteModalOpen] = useState(false);
@@ -160,6 +186,22 @@ export const TipTapCommitInput: React.FC<TipTapCommitInputProps> = ({
 
     setPendingAction('push');
     pushFiles({ path: projectPath });
+  };
+
+  const handleSshPassphraseSubmit = (sshPassphrase: string) => {
+    if (!projectPath) return;
+    setSshPassphraseAttempted(true);
+    setPendingAction('push');
+    pushFiles({
+      path: projectPath,
+      credentials: { username: '', password: '', sshPassphrase },
+    });
+  };
+
+  const handleSshPassphraseCancel = () => {
+    setSshPassphraseDialogOpen(false);
+    setSshPassphraseAttempted(false);
+    setPendingAction(null);
   };
 
   const handleCloseAddRemoteModal = () => {
@@ -428,6 +470,13 @@ export const TipTapCommitInput: React.FC<TipTapCommitInputProps> = ({
           path={projectPath}
         />
       ) : null}
+
+      <SshPassphraseModal
+        isOpen={sshPassphraseDialogOpen}
+        isLoading={isPushing}
+        onClose={handleSshPassphraseCancel}
+        onSubmit={handleSshPassphraseSubmit}
+      />
     </>
   );
 };

--- a/src/renderer/controllers/git.controller.ts
+++ b/src/renderer/controllers/git.controller.ts
@@ -12,6 +12,7 @@ import {
   FileStatus,
   GitBranch,
   GitChangesRes,
+  GitCredentials,
   RepoInfoRes,
 } from '../../types/backend';
 import { QUERY_KEYS } from '../config/constants';
@@ -281,18 +282,18 @@ export const useGitPush = (
   customOptions?: UseMutationOptions<
     { error?: string; authRequired?: boolean },
     CustomError,
-    { path: string }
+    { path: string; credentials?: GitCredentials }
   >,
 ): UseMutationResult<
   { error?: string; authRequired?: boolean },
   CustomError,
-  { path: string }
+  { path: string; credentials?: GitCredentials }
 > => {
   const { onSuccess: onCustomSuccess, onError: onCustomError } =
     customOptions || {};
   return useMutation({
     mutationFn: async (data) => {
-      return gitServices.push(data.path);
+      return gitServices.push(data.path, data.credentials);
     },
     onSuccess: async (...args) => {
       onCustomSuccess?.(...args);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSH push authentication with an in-app passphrase prompt when auth is required.
  * Users can enter an SSH key passphrase and automatically retry the push from the dialog.

* **Bug Fixes**
  * Improved push behavior for SSH vs HTTP(S) remotes, including correct upstream tracking and safer remote handling during auth retries.
  * Enhanced feedback for incorrect SSH passphrases (toast + re-prompt) and improved error handling on clone failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->