### PR TITLE
fix: notebook description placeholder and connection edit redirect

### DIFF
--- a/src/renderer/components/connections/bigquery.tsx
+++ b/src/renderer/components/connections/bigquery.tsx
@@ -116,7 +116,11 @@ export const BigQuery: React.FC<Props> = ({
     useUpdateConnection({
       onSuccess: () => {
         toast.success('BigQuery connection updated successfully!');
-        navigate('/app/project-details');
+        if (projectId) {
+          navigate('/app');
+          return;
+        }
+        navigate('/app/connections');
       },
       onError: (error) => {
         toast.error(`Update failed: ${error}`);

--- a/src/renderer/components/connections/databricks.tsx
+++ b/src/renderer/components/connections/databricks.tsx
@@ -107,6 +107,11 @@ export const Databricks: React.FC<Props> = ({
     useUpdateConnection({
       onSuccess: () => {
         toast.success('Databricks connection updated successfully!');
+        if (projectId) {
+          navigate('/app');
+          return;
+        }
+        navigate('/app/connections');
       },
       onError: (error) => {
         toast.error(`Update failed: ${error.message}`);

--- a/src/renderer/components/connections/duckdb.tsx
+++ b/src/renderer/components/connections/duckdb.tsx
@@ -90,6 +90,11 @@ export const DuckDB: React.FC<Props> = ({
     useUpdateConnection({
       onSuccess: () => {
         toast.success('DuckDB connection updated successfully!');
+        if (projectId) {
+          navigate('/app');
+          return;
+        }
+        navigate('/app/connections');
       },
       onError: (error) => {
         toast.error(`Update failed: ${error}`);

--- a/src/renderer/components/connections/kinetica.tsx
+++ b/src/renderer/components/connections/kinetica.tsx
@@ -98,6 +98,11 @@ export const Kinetica: React.FC<Props> = ({
     useUpdateConnection({
       onSuccess: () => {
         toast.success('Kinetica connection updated successfully!');
+        if (projectId) {
+          navigate('/app');
+          return;
+        }
+        navigate('/app/connections');
       },
       onError: (error) => {
         toast.error(`Update failed: ${error}`);

--- a/src/renderer/components/connections/postgres.tsx
+++ b/src/renderer/components/connections/postgres.tsx
@@ -92,6 +92,11 @@ export const Postgres: React.FC<Props> = ({
     useUpdateConnection({
       onSuccess: () => {
         toast.success('PostgreSQL connection updated successfully!');
+        if (projectId) {
+          navigate('/app');
+          return;
+        }
+        navigate('/app/connections');
       },
       onError: (error) => {
         toast.error(`Update failed: ${error}`);

--- a/src/renderer/components/connections/redshift.tsx
+++ b/src/renderer/components/connections/redshift.tsx
@@ -117,6 +117,11 @@ export const Redshift: React.FC<Props> = ({
     useUpdateConnection({
       onSuccess: () => {
         toast.success('Redshift connection updated successfully!');
+        if (projectId) {
+          navigate('/app');
+          return;
+        }
+        navigate('/app/connections');
       },
       onError: (error) => {
         toast.error(`Update failed: ${error}`);

--- a/src/renderer/components/connections/snowflake.tsx
+++ b/src/renderer/components/connections/snowflake.tsx
@@ -113,6 +113,11 @@ export const Snowflake: React.FC<Props> = ({
     useUpdateConnection({
       onSuccess: () => {
         toast.success('Snowflake connection updated successfully!');
+        if (projectId) {
+          navigate('/app');
+          return;
+        }
+        navigate('/app/connections');
       },
       onError: (error) => {
         toast.error(`Configuration failed: ${error}`);

--- a/src/renderer/screens/notebooks/index.tsx
+++ b/src/renderer/screens/notebooks/index.tsx
@@ -1308,8 +1308,6 @@ const Notebooks = () => {
             <TextField
               label="Description (optional)"
               fullWidth
-              multiline
-              rows={3}
               value={newNotebookDescription}
               onChange={(e) => setNewNotebookDescription(e.target.value)}
               placeholder="Describe what this notebook is for..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved post-update navigation for several connection types so users are sent to the most relevant screen after saving changes.
  * Connection updates now return users to the app when editing from a project, or to the connections list otherwise.
* **Style**
  * Updated the notebook description field to use a single-line input in the “Create New Notebook” dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->