### PR TITLE
fix: ensure analytics runtime is bundled in app builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "main": "./.erb/dll/main.bundle.dev.js",
   "scripts": {
+    "prebuild": "node scripts/build-analytics-runtime.mjs",
     "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
     "build:dll": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.ts",
     "build:main": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.prod.ts",
@@ -28,9 +29,8 @@
     "postinstall": "ts-node .erb/scripts/check-native-dep.js && electron-builder install-app-deps && npm run build:dll",
     "lint": "cross-env NODE_ENV=development eslint src/ --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "cross-env NODE_ENV=development eslint src/ --ext .js,.jsx,.ts,.tsx --fix",
-    "package": "ts-node ./.erb/scripts/clean.js dist && npm run build:analytics-runtime && npm run build && electron-builder build --publish never && npm run build:dll",
+    "package": "ts-node ./.erb/scripts/clean.js dist && npm run build && electron-builder build --publish never && npm run build:dll",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
-    "prepackage": "npm run build:analytics-runtime",
     "prestart": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.dev.ts",
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run prestart && npm run start:renderer",
     "start:main": "concurrently -k \"cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --watch --config ./.erb/configs/webpack.config.main.dev.ts\" \"electronmon .\"",

--- a/src/main/services/staticSite.service.ts
+++ b/src/main/services/staticSite.service.ts
@@ -31,14 +31,25 @@ import type {
   StaticSiteDeleteResult,
 } from '../../types/staticSite';
 
-const RUNTIME_BUNDLE_CANDIDATE_PATHS = [
-  // Production / packaged app: extraResources copies ./resources/** here.
-  path.join(process.resourcesPath, 'resources', 'analytics-runtime.umd.js'),
-  // Development from Electron app root.
-  path.join(app.getAppPath(), 'resources', 'analytics-runtime.umd.js'),
-  // Development from webpack dist/main output.
-  path.resolve(__dirname, '../../../../resources/analytics-runtime.umd.js'),
-];
+// Attempt to load the pre-compiled runtime bundle path
+const RUNTIME_BUNDLE_PATH = path.join(
+  app.getAppPath(),
+  'resources',
+  'analytics-runtime.umd.js',
+);
+
+// Production / packaged app — extraResources copies to process.resourcesPath
+const RUNTIME_BUNDLE_PROD_PATH = path.join(
+  process.resourcesPath,
+  'resources',
+  'analytics-runtime.umd.js',
+);
+
+// Fallback for development — look in the project root
+const RUNTIME_BUNDLE_DEV_PATH = path.resolve(
+  __dirname,
+  '../../../../resources/analytics-runtime.umd.js',
+);
 
 const MAX_ROWS_PER_QUERY = 10_000;
 
@@ -215,20 +226,10 @@ async function executeQueryInMain(params: {
 // ─── Runtime bundle resolution ────────────────────────────────────────────────
 
 function getRuntimeBundlePath(): string | null {
-  const runtimePath = RUNTIME_BUNDLE_CANDIDATE_PATHS.find((candidate) =>
-    fs.existsSync(candidate),
-  );
-  if (runtimePath) return runtimePath;
+  if (fs.existsSync(RUNTIME_BUNDLE_PROD_PATH)) return RUNTIME_BUNDLE_PROD_PATH;
+  if (fs.existsSync(RUNTIME_BUNDLE_PATH)) return RUNTIME_BUNDLE_PATH;
+  if (fs.existsSync(RUNTIME_BUNDLE_DEV_PATH)) return RUNTIME_BUNDLE_DEV_PATH;
   return null;
-}
-
-function getRuntimeBundleMissingMessage(): string {
-  return [
-    'Analytics runtime bundle is missing.',
-    'Run `npm run build:analytics-runtime` from the DBT Studio app directory, then rebuild the static site.',
-    'Searched paths:',
-    ...RUNTIME_BUNDLE_CANDIDATE_PATHS.map((candidate) => `- ${candidate}`),
-  ].join('\n');
 }
 
 // ─── Progress helper ──────────────────────────────────────────────────────────
@@ -414,7 +415,12 @@ export class StaticSiteService {
       if (runtimeSrc) {
         fs.copyFileSync(runtimeSrc, runtimeDest);
       } else {
-        throw new Error(getRuntimeBundleMissingMessage());
+        // Write a stub that shows a friendly error
+        fs.writeFileSync(
+          runtimeDest,
+          `/* analytics-runtime.umd.js not found — rebuild DBT Studio to generate it */\nwindow.AnalyticsRuntime = { mount: function(el) { el.innerHTML = '<div style="padding:32px;color:#d32f2f"><h2>Runtime bundle missing</h2><p>Please rebuild the site from DBT Studio.</p></div>'; } };`,
+          'utf-8',
+        );
       }
 
       // 8. Write per-page HTML files


### PR DESCRIPTION
 - Revert the static site runtime path refactor that broke local development and restored the previous fallback behavior.
  - Add a prebuild hook so resources/analytics-runtime.umd.js is generated before npm run build, covering both local packaging and GitHub Actions builds that call electron-builder directly after build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Builds can now continue when the analytics runtime bundle is unavailable.
  * Generated pages display a clear “Runtime bundle missing” message instead of failing completely.

* **Bug Fixes**
  * Improved runtime bundle detection across production, packaged, and development environments.
  * Simplified the build process by preparing the analytics runtime automatically before builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->