### PR TITLE
added keystore picker to push to cloud modal for environment variables

### DIFF
--- a/src/main/ipcHandlers/rosettaCloud.ipcHandlers.ts
+++ b/src/main/ipcHandlers/rosettaCloud.ipcHandlers.ts
@@ -54,8 +54,8 @@ const registerRosettaCloudIpcHandlers = () => {
 
   ipcMain.handle(
     'rosettaCloud:deleteSecret',
-    async (_event, projectId: string, secretId: string) => {
-      return RosettaCloudService.deleteSecret(projectId, secretId);
+    async (_event, body: { projectId: string; secretId: string }) => {
+      return RosettaCloudService.deleteSecret(body.projectId, body.secretId);
     },
   );
 

--- a/src/renderer/components/modals/pushToCloudModal/index.tsx
+++ b/src/renderer/components/modals/pushToCloudModal/index.tsx
@@ -20,6 +20,12 @@ import {
   Skeleton,
   Switch,
   FormControlLabel,
+  Popover,
+  List,
+  ListItemButton,
+  ListItemText,
+  ListItemIcon,
+  Tooltip,
 } from '@mui/material';
 import {
   Visibility,
@@ -31,6 +37,7 @@ import {
   Lock,
   Key,
   AddOutlined,
+  VpnKey,
 } from '@mui/icons-material';
 import { toast } from 'react-toastify';
 import { Modal } from '../modal';
@@ -42,6 +49,8 @@ import {
   useExtractProfileEnvVars,
 } from '../../../controllers';
 import { DbtCommandType, Project } from '../../../../types/backend';
+import { secureStorageService } from '../../../services/secureStorage.service';
+import { SecureStorageAccount } from '../../../../types/frontend';
 
 interface EnvironmentVariable {
   key: string;
@@ -115,6 +124,15 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
   const [newEnvKey, setNewEnvKey] = React.useState('');
   const [newEnvValue, setNewEnvValue] = React.useState('');
   const [dbtArguments, setDbtArguments] = React.useState(initialDbtArguments);
+
+  // Keystore picker state
+  const [keystoreAnchor, setKeystoreAnchor] =
+    React.useState<HTMLButtonElement | null>(null);
+  const [keystoreKeys, setKeystoreKeys] = React.useState<string[]>([]);
+  const [keystoreLoading, setKeystoreLoading] = React.useState(false);
+  const [keystoreAdding, setKeystoreAdding] = React.useState<string | null>(
+    null,
+  );
 
   React.useEffect(() => {
     setDbtArguments(initialDbtArguments);
@@ -472,6 +490,89 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
       }),
     );
   }, []);
+
+  const handleOpenKeystore = React.useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      setKeystoreAnchor(event.currentTarget);
+      setKeystoreLoading(true);
+      try {
+        const keys = await secureStorageService.list();
+        // Filter out internal/system keys (those used for db/cloud connections)
+        const userKeys = keys.filter(
+          (k) =>
+            !k.startsWith('db-') &&
+            !k.startsWith('cloud-') &&
+            !k.startsWith('openai') &&
+            !k.startsWith('ollama') &&
+            !k.startsWith('gemini') &&
+            !k.startsWith('anthropic') &&
+            !k.startsWith('lmstudio') &&
+            !k.startsWith('openai-compatible'),
+        );
+        setKeystoreKeys(userKeys);
+      } catch {
+        toast.error('Failed to load keystore entries');
+      } finally {
+        setKeystoreLoading(false);
+      }
+    },
+    [],
+  );
+
+  const handleAddFromKeystore = React.useCallback(
+    async (keystoreKey: string) => {
+      setKeystoreAdding(keystoreKey);
+      try {
+        const value = await secureStorageService.get(
+          keystoreKey as SecureStorageAccount,
+        );
+        if (value === null) {
+          toast.error(`Could not retrieve value for "${keystoreKey}"`);
+          return;
+        }
+
+        // Strip environment prefix for the variable key (e.g. "dev.MY_KEY" → "MY_KEY")
+        const varKey = keystoreKey.includes('.')
+          ? keystoreKey.slice(keystoreKey.indexOf('.') + 1)
+          : keystoreKey;
+
+        if (RESERVED_KEYS.includes(varKey.toUpperCase())) {
+          toast.error(`${varKey} is a reserved key`);
+          return;
+        }
+
+        const alreadyExists = environmentVariables.some(
+          (env) => env.key === varKey,
+        );
+        if (alreadyExists) {
+          // Update existing entry with the keystore value
+          setEnvironmentVariables((prev) =>
+            prev.map((env) =>
+              env.key === varKey ? { ...env, value, isEdited: true } : env,
+            ),
+          );
+          toast.success(`Updated "${varKey}" from keystore`);
+        } else {
+          const newEntry: EnvironmentVariable = {
+            id: `keystore-${Date.now()}`,
+            key: varKey,
+            value,
+            originalValue: value,
+            isEdited: true,
+          };
+          setEnvironmentVariables((prev) => [...prev, newEntry]);
+          toast.success(`Added "${varKey}" from keystore`);
+        }
+
+        setKeystoreAnchor(null);
+      } catch {
+        toast.error(`Failed to retrieve value for "${keystoreKey}"`);
+      } finally {
+        setKeystoreAdding(null);
+      }
+    },
+    [environmentVariables],
+  );
 
   const handleGithubUsernameFocus = React.useCallback(() => {
     if (!isGithubUsernameEdited) {
@@ -1129,13 +1230,192 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                     <AddOutlined />
                   </IconButton>
                 </Box>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ pl: 0.5 }}
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="space-between"
                 >
-                  Add additional custom environment variables.
-                </Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ pl: 0.5 }}
+                  >
+                    Add additional custom environment variables.
+                  </Typography>
+                  <Tooltip title="Pick a variable from your local keystore">
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<VpnKey sx={{ fontSize: 14 }} />}
+                      onClick={handleOpenKeystore}
+                      sx={{
+                        fontSize: '0.75rem',
+                        textTransform: 'none',
+                        borderColor: alpha(theme.palette.primary.main, 0.4),
+                        color: 'primary.main',
+                        '&:hover': {
+                          borderColor: 'primary.main',
+                          bgcolor: alpha(theme.palette.primary.main, 0.06),
+                        },
+                      }}
+                    >
+                      From Keystore
+                    </Button>
+                  </Tooltip>
+                </Box>
+
+                {/* Keystore picker popover */}
+                <Popover
+                  open={Boolean(keystoreAnchor)}
+                  anchorEl={keystoreAnchor}
+                  onClose={() => setKeystoreAnchor(null)}
+                  anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                  transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                  slotProps={{
+                    paper: {
+                      sx: {
+                        mt: 0.5,
+                        minWidth: 260,
+                        maxWidth: 360,
+                        maxHeight: 320,
+                        overflow: 'hidden',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        borderRadius: 2,
+                        border: `1px solid ${theme.palette.divider}`,
+                        boxShadow: theme.shadows[4],
+                      },
+                    },
+                  }}
+                >
+                  <Box
+                    sx={{
+                      px: 2,
+                      py: 1.5,
+                      borderBottom: `1px solid ${theme.palette.divider}`,
+                      bgcolor: alpha(
+                        theme.palette.primary.main,
+                        theme.palette.mode === 'dark' ? 0.12 : 0.04,
+                      ),
+                    }}
+                  >
+                    <Box display="flex" alignItems="center" gap={1}>
+                      <VpnKey sx={{ fontSize: 16, color: 'primary.main' }} />
+                      <Typography variant="subtitle2" fontWeight="600">
+                        Select from Keystore
+                      </Typography>
+                    </Box>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      display="block"
+                      mt={0.25}
+                    >
+                      Click a key to add it as an environment variable
+                    </Typography>
+                  </Box>
+
+                  {keystoreLoading && (
+                    <Box
+                      display="flex"
+                      justifyContent="center"
+                      alignItems="center"
+                      py={3}
+                    >
+                      <CircularProgress size={20} />
+                    </Box>
+                  )}
+                  {!keystoreLoading && keystoreKeys.length === 0 && (
+                    <Box px={2} py={3} textAlign="center">
+                      <VpnKey
+                        sx={{ fontSize: 32, color: 'text.disabled', mb: 1 }}
+                      />
+                      <Typography variant="body2" color="text.secondary">
+                        No keystore entries found.
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        display="block"
+                        mt={0.5}
+                      >
+                        Add variables in Settings → Keystore.
+                      </Typography>
+                    </Box>
+                  )}
+                  {!keystoreLoading && keystoreKeys.length > 0 && (
+                    <List
+                      dense
+                      disablePadding
+                      sx={{ overflowY: 'auto', flex: 1 }}
+                    >
+                      {keystoreKeys.map((k) => {
+                        const displayKey = k.includes('.')
+                          ? k.slice(k.indexOf('.') + 1)
+                          : k;
+                        const envPrefix = k.includes('.')
+                          ? k.slice(0, k.indexOf('.'))
+                          : null;
+                        const isAdding = keystoreAdding === k;
+                        return (
+                          <ListItemButton
+                            key={k}
+                            onClick={() => handleAddFromKeystore(k)}
+                            disabled={isAdding}
+                            sx={{
+                              py: 1,
+                              px: 2,
+                              '&:hover': {
+                                bgcolor: alpha(
+                                  theme.palette.primary.main,
+                                  0.06,
+                                ),
+                              },
+                            }}
+                          >
+                            <ListItemIcon sx={{ minWidth: 32 }}>
+                              {isAdding ? (
+                                <CircularProgress size={14} />
+                              ) : (
+                                <Key
+                                  sx={{
+                                    fontSize: 14,
+                                    color: 'text.secondary',
+                                  }}
+                                />
+                              )}
+                            </ListItemIcon>
+                            <ListItemText
+                              primary={
+                                <Typography
+                                  variant="body2"
+                                  sx={{
+                                    fontFamily: 'monospace',
+                                    fontSize: '0.8rem',
+                                    fontWeight: 600,
+                                  }}
+                                >
+                                  {displayKey}
+                                </Typography>
+                              }
+                              secondary={
+                                envPrefix && (
+                                  <Typography
+                                    variant="caption"
+                                    color="text.disabled"
+                                    sx={{ fontFamily: 'monospace' }}
+                                  >
+                                    env: {envPrefix}
+                                  </Typography>
+                                )
+                              }
+                            />
+                          </ListItemButton>
+                        );
+                      })}
+                    </List>
+                  )}
+                </Popover>
               </Stack>
             </Paper>
 

--- a/src/renderer/components/modals/pushToCloudModal/index.tsx
+++ b/src/renderer/components/modals/pushToCloudModal/index.tsx
@@ -21,11 +21,8 @@ import {
   Switch,
   FormControlLabel,
   Popover,
-  List,
-  ListItemButton,
-  ListItemText,
-  ListItemIcon,
   Tooltip,
+  Autocomplete,
 } from '@mui/material';
 import {
   Visibility,
@@ -39,7 +36,6 @@ import {
   AddOutlined,
   VpnKey,
 } from '@mui/icons-material';
-import { toast } from 'react-toastify';
 import { Modal } from '../modal';
 import {
   useGetLocalChanges,
@@ -60,7 +56,6 @@ interface EnvironmentVariable {
   isEdited?: boolean;
   originalValue?: string;
   isFromProfile?: boolean;
-  isFromKeystore?: boolean;
 }
 
 interface PushToCloudModalProps {
@@ -107,6 +102,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
   const [urlError, setUrlError] = React.useState('');
   const [titleError, setTitleError] = React.useState('');
   const [formError, setFormError] = React.useState('');
+  const [environmentError, setEnvironmentError] = React.useState('');
 
   const [githubUsername, setGithubUsername] = React.useState('');
   const [githubPassword, setGithubPassword] = React.useState('');
@@ -123,6 +119,8 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
   const [environmentVariables, setEnvironmentVariables] = React.useState<
     EnvironmentVariable[]
   >([]);
+  const [visibleEnvironmentVariableIds, setVisibleEnvironmentVariableIds] =
+    React.useState<Set<string>>(() => new Set());
   const [runTeardown, setRunTeardown] = React.useState(true);
   const [newEnvKey, setNewEnvKey] = React.useState('');
   const [newEnvValue, setNewEnvValue] = React.useState('');
@@ -387,7 +385,6 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
         secrets: reducedSecrets,
       });
 
-      await toast.success('Project deployed to cloud.');
       onClose();
     } catch (error) {
       const message =
@@ -395,9 +392,6 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
           ? error.message
           : `Failed to run project to Rosetta Cloud.`;
       setFormError(message);
-      toast.error(
-        `Unable to run project. Please review the form and try again.`,
-      );
     }
   };
 
@@ -406,12 +400,14 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
     const trimmedValue = newEnvValue.trim();
 
     if (!trimmedKey || !trimmedValue) {
-      toast.error('Both key and value are required for environment variables');
+      setEnvironmentError(
+        'Both key and value are required for environment variables.',
+      );
       return;
     }
 
     if (RESERVED_KEYS.includes(trimmedKey.toUpperCase())) {
-      toast.error(
+      setEnvironmentError(
         `${trimmedKey} is a reserved key. Please use the dedicated fields above.`,
       );
       return;
@@ -419,7 +415,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
 
     const exists = environmentVariables.some((env) => env.key === trimmedKey);
     if (exists) {
-      toast.error('Environment variable key already exists');
+      setEnvironmentError('Environment variable key already exists.');
       return;
     }
 
@@ -432,6 +428,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
     };
 
     setEnvironmentVariables((prev) => [...prev, newEnv]);
+    setEnvironmentError('');
     setNewEnvKey('');
     setNewEnvValue('');
   }, [newEnvKey, newEnvValue, environmentVariables]);
@@ -463,7 +460,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
   const updateEnvironmentVariable = React.useCallback(
     (id: string, key: string, value: string) => {
       if (RESERVED_KEYS.includes(key.toUpperCase())) {
-        toast.error(
+        setEnvironmentError(
           `${key} is a reserved key. Please use the dedicated fields.`,
         );
         return;
@@ -473,10 +470,11 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
         (env) => env.key === key && env.id !== id,
       );
       if (exists) {
-        toast.error('Environment variable key already exists');
+        setEnvironmentError('Environment variable key already exists.');
         return;
       }
 
+      setEnvironmentError('');
       setEnvironmentVariables((prev) =>
         prev.map((env) =>
           env.id === id ? { ...env, key, value, isEdited: true } : env,
@@ -517,29 +515,39 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
     );
   }, []);
 
+  const toggleEnvironmentVariableVisibility = React.useCallback(
+    (id: string) => {
+      setVisibleEnvironmentVariableIds((visibleIds) => {
+        const nextVisibleIds = new Set(visibleIds);
+        if (nextVisibleIds.has(id)) {
+          nextVisibleIds.delete(id);
+        } else {
+          nextVisibleIds.add(id);
+        }
+        return nextVisibleIds;
+      });
+    },
+    [],
+  );
+
   const handleOpenKeystore = React.useCallback(
     async (event: React.MouseEvent<HTMLButtonElement>) => {
       setKeystoreAnchor(event.currentTarget);
       setKeystoreLoading(true);
       setKeystoreKeys([]);
+      setEnvironmentError('');
       try {
         const keys = await secureStorageService.list();
-        // Filter out internal/system keys (those used for db/cloud connections)
-        const userKeys = keys.filter(
-          (k) =>
-            !k.startsWith('db-') &&
-            !k.startsWith('cloud-') &&
-            !k.startsWith('openai') &&
-            !k.startsWith('ollama') &&
-            !k.startsWith('gemini') &&
-            !k.startsWith('anthropic') &&
-            !k.startsWith('lmstudio') &&
-            !k.startsWith('openai-compatible'),
-        );
+        const userKeys = keys.filter((key) => {
+          const variableName = key.includes('.')
+            ? key.slice(key.indexOf('.') + 1)
+            : key;
+          return !RESERVED_KEYS.includes(variableName.toUpperCase());
+        });
         setKeystoreKeys(userKeys);
       } catch {
         setKeystoreKeys([]);
-        toast.error('Failed to load keystore entries');
+        setEnvironmentError('Failed to load keystore entries.');
       } finally {
         setKeystoreLoading(false);
       }
@@ -550,12 +558,13 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
   const handleAddFromKeystore = React.useCallback(
     async (keystoreKey: string) => {
       setKeystoreAdding(keystoreKey);
+      setEnvironmentError('');
       try {
         const value = await secureStorageService.get(
           keystoreKey as SecureStorageAccount,
         );
         if (value === null) {
-          toast.error(`Could not retrieve value for "${keystoreKey}"`);
+          setEnvironmentError(`Could not retrieve value for "${keystoreKey}".`);
           return;
         }
 
@@ -565,7 +574,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
           : keystoreKey;
 
         if (RESERVED_KEYS.includes(varKey.toUpperCase())) {
-          toast.error(`${varKey} is a reserved key`);
+          setEnvironmentError(`${varKey} is a reserved key.`);
           return;
         }
 
@@ -576,12 +585,9 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
           // Update existing entry with the keystore value
           setEnvironmentVariables((prev) =>
             prev.map((env) =>
-              env.key === varKey
-                ? { ...env, value, isEdited: true, isFromKeystore: true }
-                : env,
+              env.key === varKey ? { ...env, value, isEdited: true } : env,
             ),
           );
-          toast.success(`Updated "${varKey}" from keystore`);
         } else {
           const newEntry: EnvironmentVariable = {
             id: `keystore-${Date.now()}`,
@@ -589,15 +595,13 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
             value,
             originalValue: '',
             isEdited: true,
-            isFromKeystore: true,
           };
           setEnvironmentVariables((prev) => [...prev, newEntry]);
-          toast.success(`Added "${varKey}" from keystore`);
         }
 
         setKeystoreAnchor(null);
       } catch {
-        toast.error(`Failed to retrieve value for "${keystoreKey}"`);
+        setEnvironmentError(`Failed to retrieve value for "${keystoreKey}".`);
       } finally {
         setKeystoreAdding(null);
       }
@@ -1022,6 +1026,16 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
           }}
         >
           <Stack spacing={2.5}>
+            {environmentError && (
+              <Alert
+                severity="error"
+                onClose={() => setEnvironmentError('')}
+                sx={{ borderRadius: 1.5 }}
+              >
+                {environmentError}
+              </Alert>
+            )}
+
             {/* Required variables from profiles.yml */}
             {profileVars.length > 0 && (
               <>
@@ -1056,7 +1070,8 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                           variant="outlined"
                           slotProps={{ input: { readOnly: true } }}
                           sx={{
-                            flex: 1,
+                            flex: '0 0 44%',
+                            minWidth: 0,
                             '& .MuiInputBase-input': {
                               fontFamily: 'monospace',
                               fontSize: '0.875rem',
@@ -1066,7 +1081,11 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                         />
                         <TextField
                           type={
-                            isRunMode && !env.isEdited ? 'password' : 'text'
+                            (env.isEdited &&
+                              !visibleEnvironmentVariableIds.has(env.id)) ||
+                            (!env.isEdited && isRunMode && !!env.originalValue)
+                              ? 'password'
+                              : 'text'
                           }
                           value={env.value}
                           onChange={(e) =>
@@ -1080,30 +1099,48 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                           onBlur={() => handleEnvBlur(env.id)}
                           variant="outlined"
                           placeholder={
-                            isRunMode && !env.isEdited
-                              ? '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022'
+                            !env.isEdited && env.originalValue
+                              ? '******'
                               : 'Enter value'
                           }
+                          slotProps={{
+                            input: {
+                              endAdornment: env.isEdited && env.value && (
+                                <InputAdornment position="end">
+                                  <IconButton
+                                    onClick={() =>
+                                      toggleEnvironmentVariableVisibility(
+                                        env.id,
+                                      )
+                                    }
+                                    edge="end"
+                                    aria-label={
+                                      visibleEnvironmentVariableIds.has(env.id)
+                                        ? `Hide ${env.key} value`
+                                        : `Show ${env.key} value`
+                                    }
+                                  >
+                                    {visibleEnvironmentVariableIds.has(
+                                      env.id,
+                                    ) ? (
+                                      <VisibilityOff />
+                                    ) : (
+                                      <Visibility />
+                                    )}
+                                  </IconButton>
+                                </InputAdornment>
+                              ),
+                            },
+                          }}
                           sx={{
                             flex: 2,
+                            minWidth: 0,
                             '& .MuiInputBase-input': {
                               fontFamily: 'monospace',
                               fontSize: '0.875rem',
                             },
                           }}
                         />
-                        {env.isEdited && (
-                          <Chip
-                            label="Modified"
-                            size="small"
-                            sx={{
-                              height: 20,
-                              fontSize: '0.7rem',
-                              bgcolor: alpha(theme.palette.success.main, 0.1),
-                              color: 'success.main',
-                            }}
-                          />
-                        )}
                       </Box>
                     </Paper>
                   ))}
@@ -1155,7 +1192,8 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                             input: { readOnly: isRunMode },
                           }}
                           sx={{
-                            flex: 1,
+                            flex: '0 0 44%',
+                            minWidth: 0,
                             '& .MuiInputBase-input': {
                               fontFamily: 'monospace',
                               fontSize: '0.875rem',
@@ -1165,7 +1203,9 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                         />
                         <TextField
                           type={
-                            isRunMode && (!env.isEdited || env.isFromKeystore)
+                            (env.isEdited &&
+                              !visibleEnvironmentVariableIds.has(env.id)) ||
+                            (!env.isEdited && isRunMode && !!env.originalValue)
                               ? 'password'
                               : 'text'
                           }
@@ -1181,12 +1221,42 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                           onBlur={() => handleEnvBlur(env.id)}
                           variant="outlined"
                           placeholder={
-                            isRunMode && (!env.isEdited || env.isFromKeystore)
-                              ? '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022'
-                              : ''
+                            !env.isEdited && env.originalValue
+                              ? '******'
+                              : 'Enter value'
                           }
+                          slotProps={{
+                            input: {
+                              endAdornment: env.isEdited && env.value && (
+                                <InputAdornment position="end">
+                                  <IconButton
+                                    onClick={() =>
+                                      toggleEnvironmentVariableVisibility(
+                                        env.id,
+                                      )
+                                    }
+                                    edge="end"
+                                    aria-label={
+                                      visibleEnvironmentVariableIds.has(env.id)
+                                        ? `Hide ${env.key} value`
+                                        : `Show ${env.key} value`
+                                    }
+                                  >
+                                    {visibleEnvironmentVariableIds.has(
+                                      env.id,
+                                    ) ? (
+                                      <VisibilityOff />
+                                    ) : (
+                                      <Visibility />
+                                    )}
+                                  </IconButton>
+                                </InputAdornment>
+                              ),
+                            },
+                          }}
                           sx={{
                             flex: 2,
+                            minWidth: 0,
                             '& .MuiInputBase-input': {
                               fontFamily: 'monospace',
                               fontSize: '0.875rem',
@@ -1288,8 +1358,8 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                   open={Boolean(keystoreAnchor)}
                   anchorEl={keystoreAnchor}
                   onClose={() => setKeystoreAnchor(null)}
-                  anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                  transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                  anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+                  transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
                   slotProps={{
                     paper: {
                       sx: {
@@ -1334,106 +1404,104 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                     </Typography>
                   </Box>
 
-                  {keystoreLoading && (
-                    <Box
-                      display="flex"
-                      justifyContent="center"
-                      alignItems="center"
-                      py={3}
-                    >
-                      <CircularProgress size={20} />
-                    </Box>
-                  )}
-                  {!keystoreLoading && keystoreKeys.length === 0 && (
-                    <Box px={2} py={3} textAlign="center">
-                      <VpnKey
-                        sx={{ fontSize: 32, color: 'text.disabled', mb: 1 }}
-                      />
-                      <Typography variant="body2" color="text.secondary">
-                        No keystore entries found.
-                      </Typography>
+                  <Box p={2}>
+                    <Autocomplete
+                      options={keystoreKeys}
+                      value={null}
+                      loading={keystoreLoading}
+                      disabled={keystoreAdding !== null}
+                      slotProps={{
+                        popper: {
+                          sx: { zIndex: theme.zIndex.modal + 2 },
+                        },
+                        paper: {
+                          sx: { maxHeight: 280 },
+                        },
+                      }}
+                      noOptionsText={
+                        keystoreLoading
+                          ? 'Loading keystore entries…'
+                          : 'No matching keystore entries'
+                      }
+                      getOptionLabel={(key) => key}
+                      onChange={(_event, key) => {
+                        if (key) handleAddFromKeystore(key);
+                      }}
+                      renderInput={(params) => (
+                        <TextField
+                          // eslint-disable-next-line react/jsx-props-no-spreading
+                          {...params}
+                          autoFocus
+                          label="Keystore variable"
+                          placeholder="Search variables…"
+                          size="small"
+                          slotProps={{
+                            input: {
+                              ...params.InputProps,
+                              endAdornment: (
+                                <>
+                                  {keystoreAdding && (
+                                    <CircularProgress size={16} />
+                                  )}
+                                  {params.InputProps.endAdornment}
+                                </>
+                              ),
+                            },
+                          }}
+                        />
+                      )}
+                      renderOption={(props, keystoreKey) => {
+                        // eslint-disable-next-line react/prop-types
+                        const { key: optionKey, ...optionProps } = props;
+                        const displayKey = keystoreKey.includes('.')
+                          ? keystoreKey.slice(keystoreKey.indexOf('.') + 1)
+                          : keystoreKey;
+                        const envPrefix = keystoreKey.includes('.')
+                          ? keystoreKey.slice(0, keystoreKey.indexOf('.'))
+                          : null;
+                        return (
+                          <Box
+                            component="li"
+                            key={optionKey}
+                            // eslint-disable-next-line react/jsx-props-no-spreading
+                            {...optionProps}
+                          >
+                            <Box minWidth={0}>
+                              <Typography
+                                variant="body2"
+                                noWrap
+                                sx={{
+                                  fontFamily: 'monospace',
+                                  fontWeight: 600,
+                                }}
+                              >
+                                {displayKey}
+                              </Typography>
+                              {envPrefix && (
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{ fontFamily: 'monospace' }}
+                                >
+                                  env: {envPrefix}
+                                </Typography>
+                              )}
+                            </Box>
+                          </Box>
+                        );
+                      }}
+                    />
+                    {!keystoreLoading && keystoreKeys.length === 0 && (
                       <Typography
                         variant="caption"
                         color="text.secondary"
                         display="block"
-                        mt={0.5}
+                        mt={1}
                       >
                         Add variables in Settings → Keystore.
                       </Typography>
-                    </Box>
-                  )}
-                  {!keystoreLoading && keystoreKeys.length > 0 && (
-                    <List
-                      dense
-                      disablePadding
-                      sx={{ overflowY: 'auto', flex: 1 }}
-                    >
-                      {keystoreKeys.map((k) => {
-                        const displayKey = k.includes('.')
-                          ? k.slice(k.indexOf('.') + 1)
-                          : k;
-                        const envPrefix = k.includes('.')
-                          ? k.slice(0, k.indexOf('.'))
-                          : null;
-                        const isAdding = keystoreAdding === k;
-                        return (
-                          <ListItemButton
-                            key={k}
-                            onClick={() => handleAddFromKeystore(k)}
-                            disabled={keystoreAdding !== null}
-                            sx={{
-                              py: 1,
-                              px: 2,
-                              '&:hover': {
-                                bgcolor: alpha(
-                                  theme.palette.primary.main,
-                                  0.06,
-                                ),
-                              },
-                            }}
-                          >
-                            <ListItemIcon sx={{ minWidth: 32 }}>
-                              {isAdding ? (
-                                <CircularProgress size={14} />
-                              ) : (
-                                <Key
-                                  sx={{
-                                    fontSize: 14,
-                                    color: 'text.secondary',
-                                  }}
-                                />
-                              )}
-                            </ListItemIcon>
-                            <ListItemText
-                              primary={
-                                <Typography
-                                  variant="body2"
-                                  sx={{
-                                    fontFamily: 'monospace',
-                                    fontSize: '0.8rem',
-                                    fontWeight: 600,
-                                  }}
-                                >
-                                  {displayKey}
-                                </Typography>
-                              }
-                              secondary={
-                                envPrefix && (
-                                  <Typography
-                                    variant="caption"
-                                    color="text.disabled"
-                                    sx={{ fontFamily: 'monospace' }}
-                                  >
-                                    env: {envPrefix}
-                                  </Typography>
-                                )
-                              }
-                            />
-                          </ListItemButton>
-                        );
-                      })}
-                    </List>
-                  )}
+                    )}
+                  </Box>
                 </Popover>
               </Stack>
             </Paper>

--- a/src/renderer/components/modals/pushToCloudModal/index.tsx
+++ b/src/renderer/components/modals/pushToCloudModal/index.tsx
@@ -447,7 +447,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
       // If the project is deployed and the variable has a real cloud secret ID
       // (not a locally-added one, which uses Date.now() as id), delete it from
       // the cloud so it doesn't reappear on the next modal open or pipeline run.
-      const isLocallyAdded = /^\d+$/.test(id);
+      const isLocallyAdded = /^\d+$/.test(id) || id.startsWith('keystore-');
       if (envVar && project?.id && !isLocallyAdded) {
         deleteSecretFromCloud({ projectId: project.id, secretId: id }).catch(
           () => {

--- a/src/renderer/components/modals/pushToCloudModal/index.tsx
+++ b/src/renderer/components/modals/pushToCloudModal/index.tsx
@@ -45,6 +45,7 @@ import {
   useGetLocalChanges,
   useGetRepoInfo,
   useGetSecrets,
+  useDeleteSecret,
   usePushProjectToCloud,
   useExtractProfileEnvVars,
 } from '../../../controllers';
@@ -87,6 +88,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
   );
   const { mutateAsync: pushProject, isLoading: isPushing } =
     usePushProjectToCloud();
+  const { mutateAsync: deleteSecretFromCloud } = useDeleteSecret();
   const isDeployed = !!project?.externalId;
   const {
     data: secrets = [],
@@ -434,9 +436,29 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
     setNewEnvValue('');
   }, [newEnvKey, newEnvValue, environmentVariables]);
 
-  const removeEnvironmentVariable = React.useCallback((id: string) => {
-    setEnvironmentVariables((prev) => prev.filter((env) => env.id !== id));
-  }, []);
+  const removeEnvironmentVariable = React.useCallback(
+    (id: string) => {
+      // Find the variable to check whether it's an existing cloud secret
+      const envVar = environmentVariables.find((e) => e.id === id);
+
+      // Remove from local state immediately
+      setEnvironmentVariables((prev) => prev.filter((env) => env.id !== id));
+
+      // If the project is deployed and the variable has a real cloud secret ID
+      // (not a locally-added one, which uses Date.now() as id), delete it from
+      // the cloud so it doesn't reappear on the next modal open or pipeline run.
+      const isLocallyAdded = /^\d+$/.test(id);
+      if (envVar && project?.id && !isLocallyAdded) {
+        deleteSecretFromCloud({ projectId: project.id, secretId: id }).catch(
+          () => {
+            // Best-effort: cloud delete failures are non-fatal here since the
+            // user can always retry. Don't block the UX.
+          },
+        );
+      }
+    },
+    [environmentVariables, project?.id, deleteSecretFromCloud],
+  );
 
   const updateEnvironmentVariable = React.useCallback(
     (id: string, key: string, value: string) => {

--- a/src/renderer/components/modals/pushToCloudModal/index.tsx
+++ b/src/renderer/components/modals/pushToCloudModal/index.tsx
@@ -59,6 +59,7 @@ interface EnvironmentVariable {
   isEdited?: boolean;
   originalValue?: string;
   isFromProfile?: boolean;
+  isFromKeystore?: boolean;
 }
 
 interface PushToCloudModalProps {
@@ -342,9 +343,8 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
     }
 
     try {
-      // Only include edited environment variables
       const reducedSecrets = environmentVariables
-        .filter((env) => env.isEdited)
+        .filter((env) => env.isEdited || !env.isFromProfile)
         .reduce(
           (acc, env) => {
             acc[env.key] = env.value;
@@ -468,7 +468,12 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
     setEnvironmentVariables((prev) =>
       prev.map((env) =>
         env.id === id
-          ? { ...env, value: env.isEdited ? env.value : '', isEdited: true }
+          ? {
+              ...env,
+              value: env.isEdited ? env.value : '',
+              isEdited: true,
+              isFromKeystore: false,
+            }
           : env,
       ),
     );
@@ -495,6 +500,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
     async (event: React.MouseEvent<HTMLButtonElement>) => {
       setKeystoreAnchor(event.currentTarget);
       setKeystoreLoading(true);
+      setKeystoreKeys([]);
       try {
         const keys = await secureStorageService.list();
         // Filter out internal/system keys (those used for db/cloud connections)
@@ -511,6 +517,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
         );
         setKeystoreKeys(userKeys);
       } catch {
+        setKeystoreKeys([]);
         toast.error('Failed to load keystore entries');
       } finally {
         setKeystoreLoading(false);
@@ -548,7 +555,9 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
           // Update existing entry with the keystore value
           setEnvironmentVariables((prev) =>
             prev.map((env) =>
-              env.key === varKey ? { ...env, value, isEdited: true } : env,
+              env.key === varKey
+                ? { ...env, value, isEdited: true, isFromKeystore: true }
+                : env,
             ),
           );
           toast.success(`Updated "${varKey}" from keystore`);
@@ -557,8 +566,9 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
             id: `keystore-${Date.now()}`,
             key: varKey,
             value,
-            originalValue: value,
+            originalValue: '',
             isEdited: true,
+            isFromKeystore: true,
           };
           setEnvironmentVariables((prev) => [...prev, newEntry]);
           toast.success(`Added "${varKey}" from keystore`);
@@ -1134,7 +1144,9 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                         />
                         <TextField
                           type={
-                            isRunMode && !env.isEdited ? 'password' : 'text'
+                            isRunMode && (!env.isEdited || env.isFromKeystore)
+                              ? 'password'
+                              : 'text'
                           }
                           value={env.value}
                           onChange={(e) =>
@@ -1148,7 +1160,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                           onBlur={() => handleEnvBlur(env.id)}
                           variant="outlined"
                           placeholder={
-                            isRunMode && !env.isEdited
+                            isRunMode && (!env.isEdited || env.isFromKeystore)
                               ? '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022'
                               : ''
                           }
@@ -1347,7 +1359,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                           <ListItemButton
                             key={k}
                             onClick={() => handleAddFromKeystore(k)}
-                            disabled={isAdding}
+                            disabled={keystoreAdding !== null}
                             sx={{
                               py: 1,
                               px: 2,

--- a/src/renderer/components/modals/pushToCloudModal/index.tsx
+++ b/src/renderer/components/modals/pushToCloudModal/index.tsx
@@ -1160,32 +1160,18 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
                             },
                           }}
                         />
-                        {!isRunMode && (
-                          <IconButton
-                            onClick={() => removeEnvironmentVariable(env.id)}
-                            sx={{
-                              color: 'error.main',
-                              bgcolor: alpha(theme.palette.error.main, 0.08),
-                              '&:hover': {
-                                bgcolor: alpha(theme.palette.error.main, 0.15),
-                              },
-                            }}
-                          >
-                            <Delete />
-                          </IconButton>
-                        )}
-                        {env.isEdited && (
-                          <Chip
-                            label="Modified"
-                            size="small"
-                            sx={{
-                              height: 20,
-                              fontSize: '0.7rem',
-                              bgcolor: alpha(theme.palette.success.main, 0.1),
-                              color: 'success.main',
-                            }}
-                          />
-                        )}
+                        <IconButton
+                          onClick={() => removeEnvironmentVariable(env.id)}
+                          sx={{
+                            color: 'error.main',
+                            bgcolor: alpha(theme.palette.error.main, 0.08),
+                            '&:hover': {
+                              bgcolor: alpha(theme.palette.error.main, 0.15),
+                            },
+                          }}
+                        >
+                          <Delete />
+                        </IconButton>
                       </Box>
                     </Paper>
                   ))}

--- a/src/renderer/components/modals/pushToCloudModal/index.tsx
+++ b/src/renderer/components/modals/pushToCloudModal/index.tsx
@@ -472,7 +472,6 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
               ...env,
               value: env.isEdited ? env.value : '',
               isEdited: true,
-              isFromKeystore: false,
             }
           : env,
       ),

--- a/src/renderer/controllers/rosettaCloud.controller.ts
+++ b/src/renderer/controllers/rosettaCloud.controller.ts
@@ -88,6 +88,22 @@ export const useGetSecrets = (
   });
 };
 
+export const useDeleteSecret = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      projectId,
+      secretId,
+    }: {
+      projectId: string;
+      secretId: string;
+    }) => rosettaCloudServices.deleteSecret(projectId, secretId),
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEYS.CLOUD_SECRETS]);
+    },
+  });
+};
+
 export const useAuthLogin = (
   options?: UseMutationOptions<string, CustomError, void>,
 ): UseAuthLoginResult => {

--- a/src/renderer/controllers/rosettaCloud.controller.ts
+++ b/src/renderer/controllers/rosettaCloud.controller.ts
@@ -82,9 +82,10 @@ export const useGetSecrets = (
   options?: UseQueryOptions<Secret[], CustomError, Secret[]>,
 ) => {
   return useQuery({
-    queryKey: [QUERY_KEYS.CLOUD_SECRETS],
-    queryFn: () => rosettaCloudServices.getSecrets(projectId ?? ''),
+    queryKey: [QUERY_KEYS.CLOUD_SECRETS, projectId],
+    queryFn: () => rosettaCloudServices.getSecrets(projectId!),
     ...options,
+    enabled: !!projectId && (options?.enabled ?? true),
   });
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “From Keystore” support to import environment variables via a keystore picker with autocomplete, loading/empty states, and automatic mapping into editable variables.
* **UI Improvements**
  * Improved masking/placeholder and run-mode visibility, including per-row show/hide toggles and focus-driven “edited” state.
  * Deletion controls are now always available for custom variables; removing a cloud-backed secret triggers best-effort deletion and refreshes the secrets list.
* **Bug Fixes**
  * Submission now includes edited variables plus appropriate non-profile entries.
  * Keystore/import and submission errors are surfaced in the modal’s alert area (no success/error toasts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->