### PR TITLE
feat(terminal): add AI Agent assist action

### DIFF
--- a/src/renderer/components/terminal/aiAssist.ts
+++ b/src/renderer/components/terminal/aiAssist.ts
@@ -1,0 +1,17 @@
+const TERMINAL_AI_PROMPT =
+  'Diagnose the following terminal output, explain the cause, and suggest the next steps to resolve it:';
+
+export const buildTerminalAiPrompt = (
+  selectedText: string,
+  output: string[],
+  error: string[],
+): string | null => {
+  const selection = selectedText.trim();
+  const terminalText = selection || [...output, ...error].join('\n').trim();
+
+  if (!terminalText) {
+    return null;
+  }
+
+  return `${TERMINAL_AI_PROMPT}\n\n\`\`\`text\n${terminalText}\n\`\`\``;
+};

--- a/src/renderer/components/terminal/processTerminal.tsx
+++ b/src/renderer/components/terminal/processTerminal.tsx
@@ -12,13 +12,15 @@ import {
   Divider,
 } from '@mui/material';
 import {
+  AutoAwesome as AiAssistIcon,
   ContentCopy as CopyIcon,
   ContentPasteSearch as CopyAllIcon,
   DeleteSweep as ClearIcon,
 } from '@mui/icons-material';
 import AnsiToHtml from 'ansi-to-html';
-import { useProcess } from '../../hooks';
+import { useAppContext, useProcess } from '../../hooks';
 import { OutputBox, TerminalContainer } from './styles';
+import { buildTerminalAiPrompt } from './aiAssist';
 
 const ProcessTerminal: React.FC = () => {
   const { mode } = useColorScheme();
@@ -34,6 +36,7 @@ const ProcessTerminal: React.FC = () => {
     duration,
     status,
   } = useProcess();
+  const { openChatWithMessage } = useAppContext();
   const outputRef = React.useRef<HTMLDivElement>(null);
 
   const [contextMenu, setContextMenu] = React.useState<{
@@ -95,6 +98,19 @@ const ProcessTerminal: React.FC = () => {
     const allText = [...output, ...error].join('\n');
     if (allText) {
       navigator.clipboard.writeText(allText);
+    }
+    handleClose();
+  };
+
+  const aiPrompt = buildTerminalAiPrompt(
+    contextMenu?.selectedText ?? '',
+    output,
+    error,
+  );
+
+  const handleAskAi = () => {
+    if (aiPrompt) {
+      openChatWithMessage(aiPrompt);
     }
     handleClose();
   };
@@ -320,6 +336,22 @@ const ProcessTerminal: React.FC = () => {
             primaryTypographyProps={{ variant: 'body2', fontSize: 12 }}
           >
             Copy All
+          </ListItemText>
+        </MenuItem>
+        <Divider sx={{ my: '4px !important' }} />
+        <MenuItem
+          onClick={handleAskAi}
+          dense
+          sx={{ py: 0.5, px: 1.5 }}
+          disabled={!aiPrompt}
+        >
+          <ListItemIcon sx={{ minWidth: '28px !important' }}>
+            <AiAssistIcon sx={{ fontSize: 16 }} />
+          </ListItemIcon>
+          <ListItemText
+            primaryTypographyProps={{ variant: 'body2', fontSize: 12 }}
+          >
+            Ask AI Agent
           </ListItemText>
         </MenuItem>
         <Divider sx={{ my: '4px !important' }} />

--- a/src/renderer/components/terminal/terminal.tsx
+++ b/src/renderer/components/terminal/terminal.tsx
@@ -10,16 +10,18 @@ import {
   Divider,
 } from '@mui/material';
 import {
+  AutoAwesome as AiAssistIcon,
   ContentCopy as CopyIcon,
   ContentPasteSearch as CopyAllIcon,
   DeleteSweep as ClearIcon,
 } from '@mui/icons-material';
 import { toast } from 'react-toastify';
 import AnsiToHtml from 'ansi-to-html';
-import { useCli, useCommandHistory } from '../../hooks';
+import { useAppContext, useCli, useCommandHistory } from '../../hooks';
 import { OutputBox, StyledInput, TerminalContainer, InputLine } from './styles';
 import { useGetSettings } from '../../controllers';
 import { Project } from '../../../types/backend';
+import { buildTerminalAiPrompt } from './aiAssist';
 
 type Props = {
   project: Project;
@@ -34,6 +36,7 @@ export const Terminal: React.FC<Props> = ({ project }) => {
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const { data: settings } = useGetSettings();
   const { record, getPrev, getNext, resetPointer } = useCommandHistory();
+  const { openChatWithMessage } = useAppContext();
 
   const [contextMenu, setContextMenu] = React.useState<{
     mouseX: number;
@@ -94,6 +97,19 @@ export const Terminal: React.FC<Props> = ({ project }) => {
     const allText = [...output, ...error].join('\n');
     if (allText) {
       navigator.clipboard.writeText(allText);
+    }
+    handleClose();
+  };
+
+  const aiPrompt = buildTerminalAiPrompt(
+    contextMenu?.selectedText ?? '',
+    output,
+    error,
+  );
+
+  const handleAskAi = () => {
+    if (aiPrompt) {
+      openChatWithMessage(aiPrompt);
     }
     handleClose();
   };
@@ -400,6 +416,22 @@ export const Terminal: React.FC<Props> = ({ project }) => {
             primaryTypographyProps={{ variant: 'body2', fontSize: 12 }}
           >
             Copy All
+          </ListItemText>
+        </MenuItem>
+        <Divider sx={{ my: '4px !important' }} />
+        <MenuItem
+          onClick={handleAskAi}
+          dense
+          sx={{ py: 0.5, px: 1.5 }}
+          disabled={!aiPrompt}
+        >
+          <ListItemIcon sx={{ minWidth: '28px !important' }}>
+            <AiAssistIcon sx={{ fontSize: 16 }} />
+          </ListItemIcon>
+          <ListItemText
+            primaryTypographyProps={{ variant: 'body2', fontSize: 12 }}
+          >
+            Ask AI Agent
           </ListItemText>
         </MenuItem>
         <Divider sx={{ my: '4px !important' }} />

--- a/tests/unit/renderer/components/terminalAiAssist.test.ts
+++ b/tests/unit/renderer/components/terminalAiAssist.test.ts
@@ -1,0 +1,25 @@
+import { buildTerminalAiPrompt } from '../../../../src/renderer/components/terminal/aiAssist';
+
+describe('buildTerminalAiPrompt', () => {
+  it('uses selected text when the user selected terminal output', () => {
+    const prompt = buildTerminalAiPrompt(
+      'Database Error',
+      ['successful setup'],
+      ['different error'],
+    );
+
+    expect(prompt).toContain('Database Error');
+    expect(prompt).not.toContain('successful setup');
+    expect(prompt).not.toContain('different error');
+  });
+
+  it('uses all output when there is no selection', () => {
+    const prompt = buildTerminalAiPrompt('', ['dbt run'], ['Database Error']);
+
+    expect(prompt).toContain('dbt run\nDatabase Error');
+  });
+
+  it('returns null when the terminal has no text', () => {
+    expect(buildTerminalAiPrompt('  ', [], [])).toBeNull();
+  });
+});


### PR DESCRIPTION
Add an "Ask AI Agent" option to the regular and process terminal context menus. The action sends selected terminal text, or the full output when no text is selected, to the AI Agent ChatScreen with a diagnostic prompt.

Add unit tests covering selected text, full-output fallback, and empty terminal output.