### PR TITLE
fix: Getting Started Pipeline title of tab stays pipeline.yml and expand cloud logs panel automatically when pipeline run starts

### DIFF
--- a/src/renderer/components/modals/pushToCloudModal/index.tsx
+++ b/src/renderer/components/modals/pushToCloudModal/index.tsx
@@ -61,6 +61,7 @@ interface EnvironmentVariable {
 interface PushToCloudModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onSuccess?: () => void;
   project: Project;
   command: DbtCommandType;
   initialDbtArguments?: string;
@@ -71,6 +72,7 @@ const RESERVED_KEYS = ['ROSETTA_GIT_USER', 'ROSETTA_GIT_PASSWORD'];
 export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
   isOpen,
   onClose,
+  onSuccess,
   project,
   command,
   initialDbtArguments = '',
@@ -385,6 +387,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
         secrets: reducedSecrets,
       });
 
+      onSuccess?.();
       onClose();
     } catch (error) {
       const message =

--- a/src/renderer/components/sidebar/project-sidebar.tsx
+++ b/src/renderer/components/sidebar/project-sidebar.tsx
@@ -290,9 +290,10 @@ const ExplorerTab: React.FC<ExplorerTabProps> = ({
       await refetchPipelines();
       await onRefreshFiles();
       // Open the newly created pipeline file in the editor
+      const fileName = filePath.split('/').pop() ?? 'pipeline.yml';
       onFileSelect({
         id: filePath,
-        name: 'pipeline.yml',
+        name: fileName,
         path: filePath,
         type: 'file' as const,
       });

--- a/src/renderer/screens/projectDetails/index.tsx
+++ b/src/renderer/screens/projectDetails/index.tsx
@@ -1506,6 +1506,7 @@ const ProjectDetails: React.FC = () => {
                     setPipelineCloudModal(false);
                     setPipelineRunArgs('');
                   }}
+                  onSuccess={() => setPipelineLogsMinimized(false)}
                   project={project}
                   command="pipeline"
                   initialDbtArguments={pipelineRunArgs}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored pipeline cloud logs automatically after a successful push to the cloud.
  * Improved pipeline selection by displaying the correct filename for newly created pipelines.

* **Bug Fixes**
  * Added success handling after cloud pushes so related interface updates occur before the dialog closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->