### PR TITLE
fix(sql-editor): open saved queries on single click and fix modified indicator

### DIFF
--- a/src/renderer/components/sqlEditor/SavedQueriesList.tsx
+++ b/src/renderer/components/sqlEditor/SavedQueriesList.tsx
@@ -214,7 +214,7 @@ export const SavedQueriesList: React.FC<SavedQueriesListProps> = ({
       <Box
         key={query.id}
         onContextMenu={(e) => handleContextMenu(e, query)}
-        onDoubleClick={() => onOpenQuery(query.query)}
+        onClick={() => onOpenQuery(query.query)}
         sx={{
           display: 'flex',
           alignItems: 'flex-start',

--- a/src/renderer/components/sqlTabs/index.tsx
+++ b/src/renderer/components/sqlTabs/index.tsx
@@ -13,7 +13,6 @@ import {
   SqlTabButton,
   TabTitle,
   TabIcon,
-  ModifiedDot,
   LoadingDot,
   EmptyTabsPlaceholder,
 } from './styles';
@@ -66,7 +65,6 @@ const SqlTab: React.FC<SqlTabProps> = ({
         }}
       >
         {tab.isLoading && <LoadingDot />}
-        {!tab.isLoading && tab.isModified && <ModifiedDot />}
         {!tab.isLoading && tab.error && (
           <Tooltip
             title={tab.error}

--- a/src/renderer/components/sqlTabs/styles.ts
+++ b/src/renderer/components/sqlTabs/styles.ts
@@ -116,15 +116,6 @@ export const TabIcon = styled('img')(() => ({
   objectFit: 'contain',
 }));
 
-export const ModifiedDot = styled('span')<{ hidden?: boolean }>(
-  ({ theme, hidden }) => ({
-    width: 8,
-    height: 8,
-    borderRadius: 999,
-    backgroundColor: hidden ? 'transparent' : theme.palette.warning.main,
-  }),
-);
-
 export const LoadingDot = styled('span')(({ theme }) => ({
   width: 8,
   height: 8,


### PR DESCRIPTION
- Load saved query content with one click
- Remove the modified indicator from autosaved SQL tabs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Usability Improvements**
  - Saved queries now open with a single click instead of a double-click.
  - Right-click context menu behavior remains unchanged.

- **UI Changes**
  - Removed the modified-state indicator from SQL editor tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->