### PR TITLE
fix(run-history): prevent completed dbt commands from staying loading

### DIFF
--- a/src/renderer/components/dbtRunHistory/DbtRunHistoryRunRow.tsx
+++ b/src/renderer/components/dbtRunHistory/DbtRunHistoryRunRow.tsx
@@ -8,6 +8,7 @@ import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import WarningIcon from '@mui/icons-material/Warning';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
 
 import { DbtRunHistoryEntry } from '../../../types/dbtRunHistory';
 import { DbtRunHistoryResultRow } from './DbtRunHistoryResultRow';
@@ -34,6 +35,8 @@ const getStatusIcon = (status: string) => {
           sx={{ animation: 'spin 2s linear infinite' }}
         />
       );
+    case 'cancelled':
+      return <CancelOutlinedIcon color="disabled" fontSize="small" />;
     default:
       return <CheckCircleIcon color="disabled" fontSize="small" />;
   }

--- a/src/renderer/components/dbtRunHistory/DbtRunHistoryToolbar.tsx
+++ b/src/renderer/components/dbtRunHistory/DbtRunHistoryToolbar.tsx
@@ -66,6 +66,7 @@ export const DbtRunHistoryToolbar: React.FC<Props> = ({
         <MenuItem value="error">Error</MenuItem>
         <MenuItem value="warn">Warning</MenuItem>
         <MenuItem value="running">Running</MenuItem>
+        <MenuItem value="cancelled">Cancelled</MenuItem>
       </Select>
 
       <TextField

--- a/src/renderer/hooks/useDbt.ts
+++ b/src/renderer/hooks/useDbt.ts
@@ -349,13 +349,13 @@ const useDbt = (
           }
           // Only attach run_results.json for commands that actually produce it
           const commandsWithRunResults = ['run', 'test', 'seed', 'snapshot'];
-          if (commandsWithRunResults.includes(command)) {
-            await recordCommandFinished(
-              runHistoryId,
-              project.id,
-              `${project.path}/target/run_results.json`,
-            );
-          }
+          await recordCommandFinished(
+            runHistoryId,
+            project.id,
+            commandsWithRunResults.includes(command)
+              ? `${project.path}/target/run_results.json`
+              : undefined,
+          );
           successCallback?.();
         } else {
           if (options.showToast) {

--- a/src/renderer/hooks/useDbtRunHistory.ts
+++ b/src/renderer/hooks/useDbtRunHistory.ts
@@ -7,6 +7,30 @@ import {
 
 const MAX_HISTORY = 50;
 const EVENT_NAME = 'dbt-run-history-changed';
+const SESSION_ID = `session-${Date.now()}-${Math.random()
+  .toString(36)
+  .slice(2, 11)}`;
+
+function recoverInterruptedRuns(entries: DbtRunHistoryEntry[]): {
+  entries: DbtRunHistoryEntry[];
+  changed: boolean;
+} {
+  let changed = false;
+  const recovered = entries.map((entry) => {
+    if (entry.status !== 'running' || entry.sessionId === SESSION_ID) {
+      return entry;
+    }
+    changed = true;
+    return {
+      ...entry,
+      status: 'cancelled' as const,
+      completedAt: entry.completedAt || new Date().toISOString(),
+      errorMessage:
+        entry.errorMessage || 'Command was interrupted before completion.',
+    };
+  });
+  return { entries: recovered, changed };
+}
 
 function dispatchChangeEvent() {
   window.dispatchEvent(new Event(EVENT_NAME));
@@ -91,7 +115,13 @@ export const useDbtRunHistory = (projectId?: string) => {
       if (!key) return [];
       try {
         const data = localStorage.getItem(key);
-        return data ? JSON.parse(data) : [];
+        if (!data) return [];
+        const parsed = JSON.parse(data) as DbtRunHistoryEntry[];
+        const recovered = recoverInterruptedRuns(parsed);
+        if (recovered.changed) {
+          localStorage.setItem(key, JSON.stringify(recovered.entries));
+        }
+        return recovered.entries;
       } catch {
         return [];
       }
@@ -131,6 +161,7 @@ export const useDbtRunHistory = (projectId?: string) => {
       const newEntry: DbtRunHistoryEntry = {
         ...request,
         id: `run-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        sessionId: SESSION_ID,
         status: 'running',
         startedAt: new Date().toISOString(),
         summary: { total: 0, success: 0, error: 0, warn: 0, skipped: 0 },

--- a/src/types/dbtRunHistory.ts
+++ b/src/types/dbtRunHistory.ts
@@ -23,6 +23,7 @@ export interface DbtRunHistoryResult {
 
 export interface DbtRunHistoryEntry {
   id: string;
+  sessionId?: string;
   invocationId?: string;
   projectId?: string;
   projectName: string;

--- a/tests/unit/renderer/hooks/useDbtRunHistory.test.tsx
+++ b/tests/unit/renderer/hooks/useDbtRunHistory.test.tsx
@@ -1,0 +1,66 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDbtRunHistory } from '../../../../src/renderer/hooks/useDbtRunHistory';
+
+describe('useDbtRunHistory', () => {
+  const projectId = 'project-1';
+  const storageKey = `dbt-studio:run-history:${projectId}`;
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('recovers a running command left by an earlier renderer session', () => {
+    localStorage.setItem(
+      storageKey,
+      JSON.stringify([
+        {
+          id: 'stale-run',
+          projectId,
+          projectName: 'Project',
+          projectPath: '/projects/project-1',
+          command: 'debug',
+          fullCommand: 'dbt debug',
+          status: 'running',
+          startedAt: '2026-07-22T09:24:41.000Z',
+          summary: { total: 0, success: 0, error: 0, warn: 0, skipped: 0 },
+        },
+      ]),
+    );
+
+    const { result } = renderHook(() => useDbtRunHistory(projectId));
+
+    expect(result.current.history[0]).toMatchObject({
+      id: 'stale-run',
+      status: 'cancelled',
+      errorMessage: 'Command was interrupted before completion.',
+    });
+    expect(JSON.parse(localStorage.getItem(storageKey) || '[]')[0].status).toBe(
+      'cancelled',
+    );
+  });
+
+  it('finishes successful commands that do not have an artifact', async () => {
+    const { result } = renderHook(() => useDbtRunHistory(projectId));
+    let runId = '';
+
+    act(() => {
+      runId = result.current.recordCommandStart({
+        projectId,
+        projectName: 'Project',
+        projectPath: '/projects/project-1',
+        command: 'deps',
+        fullCommand: 'dbt deps',
+      });
+    });
+
+    await act(async () => {
+      await result.current.recordCommandFinished(runId, projectId);
+    });
+
+    expect(result.current.history[0]).toMatchObject({
+      id: runId,
+      status: 'success',
+    });
+    expect(result.current.history[0].completedAt).toBeDefined();
+  });
+});


### PR DESCRIPTION
- finalize successful commands without run artifacts
- recover interrupted runs as cancelled after restart
- add cancelled status icon and filter
- cover run-history recovery and completion behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying and filtering cancelled runs in run history.
  * Interrupted runs from previous sessions are now automatically marked as cancelled with completion details.

* **Bug Fixes**
  * Command history now records successful commands consistently, including commands without result artifacts.

* **Tests**
  * Added coverage for recovering interrupted runs and completing commands without artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->