### PR TITLE
fix: upgrade and lock electron version to 31.7.6 to bypass macOS XProtect malware false positive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
         "css-minimizer-webpack-plugin": "^5.0.1",
         "detect-port": "^1.5.1",
         "drizzle-kit": "^0.31.4",
-        "electron": "^31.3.0",
+        "electron": "^31.7.6",
         "electron-builder": "^24.13.3",
         "electron-devtools-installer": "^3.2.0",
         "electronmon": "^2.0.2",
@@ -15821,11 +15821,12 @@
       }
     },
     "node_modules/electron": {
-      "version": "31.7.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-31.7.7.tgz",
-      "integrity": "sha512-HZtZg8EHsDGnswFt0QeV8If8B+et63uD6RJ7I4/xhcXqmTIbI08GoubX/wm+HdY0DwcuPe1/xsgqpmYvjdjRoA==",
+      "version": "31.7.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.7.6.tgz",
+      "integrity": "sha512-fc2kMaEc/zxGTW6oCxbuE7BQNOlDucSo+351AiovBAcp7G0iQkVu3k2kHIQolSsD38+tPdBj/N02DVpZTzi7rg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^20.9.0",
@@ -19939,18 +19940,6 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "dev": true
-    },
-    "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
     },
     "node_modules/immutable": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "css-minimizer-webpack-plugin": "^5.0.1",
     "detect-port": "^1.5.1",
     "drizzle-kit": "^0.31.4",
-    "electron": "^31.3.0",
+    "electron": "31.7.6",
     "electron-builder": "^24.13.3",
     "electron-devtools-installer": "^3.2.0",
     "electronmon": "^2.0.2",
@@ -331,7 +331,7 @@
     "extraResources": [
       "./assets/**",
       "./resources/**"
- ],
+    ],
     "publish": {
       "provider": "github",
       "owner": "rosettadb",


### PR DESCRIPTION
Upgrades and locks the `electron` dependency from `^31.3.0` strictly to `31.7.6`.

Electron v31.7.7 is currently experiencing a false-positive detection by Apple's built-in XProtect/Gatekeeper scanner on macOS (specifically seen on macOS 15.7.2). This was causing the `Electron.app` binary in `node_modules` to be incorrectly flagged as malware and moved to the Trash immediately upon running `npm start` or trying to execute the binary.

By pinning specifically to 31.7.6, we ensure we get the latest stable updates for the v31 branch while avoiding the malware false-positive introduced in 31.7.7, allowing the application to successfully start again without interference from the OS security layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Electron development tooling to a fixed version for more consistent builds.
  * Applied minor configuration formatting cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->