### PR TITLE
Update/transition pipelines to rosetta folder

### DIFF
--- a/src/main/ipcHandlers/projects.ipcHandlers.ts
+++ b/src/main/ipcHandlers/projects.ipcHandlers.ts
@@ -130,6 +130,13 @@ const registerProjectHandlers = () => {
   );
 
   ipcMain.handle(
+    'project:createFolderAsync',
+    async (_event, body: { filePath: string; name: string }) => {
+      return ProjectsService.createFolderAsync(body);
+    },
+  );
+
+  ipcMain.handle(
     'project:createFile',
     async (
       _event,

--- a/src/main/services/projects.service.ts
+++ b/src/main/services/projects.service.ts
@@ -1337,7 +1337,7 @@ export default class ProjectsService {
   }
 
   /**
-   * List pipeline YAML files under .rosetta/ directory
+   * List pipeline YAML files under rosetta/pipelines/ directory
    */
   static async listPipelines(
     projectId: string,
@@ -1345,17 +1345,17 @@ export default class ProjectsService {
     const project = await this.getProject(projectId);
     if (!project) throw new Error('Project not found');
 
-    const rosettaDir = path.join(project.path, '.rosetta');
-    if (!fs.existsSync(rosettaDir)) return [];
+    const pipelinesDir = path.join(project.path, 'rosetta', 'pipelines');
+    if (!fs.existsSync(pipelinesDir)) return [];
 
-    const entries = await fs.promises.readdir(rosettaDir);
+    const entries = await fs.promises.readdir(pipelinesDir);
     return entries
       .filter(
         (f) => (f.endsWith('.yml') || f.endsWith('.yaml')) && f !== 'main.conf',
       )
       .map((f) => ({
         name: f.replace(/\.(yml|yaml)$/, ''),
-        path: path.join(rosettaDir, f),
+        path: path.join(pipelinesDir, f),
       }));
   }
 }

--- a/src/main/services/projects.service.ts
+++ b/src/main/services/projects.service.ts
@@ -1337,7 +1337,29 @@ export default class ProjectsService {
   }
 
   /**
-   * List pipeline YAML files under rosetta/pipelines/ directory
+   * List pipeline YAML files in a directory, ignoring non-pipeline yaml
+   * files such as main.conf.
+   */
+  private static async listPipelineFilesInDir(
+    dir: string,
+  ): Promise<{ name: string; path: string }[]> {
+    if (!fs.existsSync(dir)) return [];
+
+    const entries = await fs.promises.readdir(dir);
+    return entries
+      .filter(
+        (f) => (f.endsWith('.yml') || f.endsWith('.yaml')) && f !== 'main.conf',
+      )
+      .map((f) => ({
+        name: f.replace(/\.(yml|yaml)$/, ''),
+        path: path.join(dir, f),
+      }));
+  }
+
+  /**
+   * List pipeline YAML files under rosetta/pipelines/ (current location) and
+   * .rosetta/ (deprecated location, kept during the transition to
+   * rosetta/pipelines/ — remove once existing projects have migrated).
    */
   static async listPipelines(
     projectId: string,
@@ -1346,16 +1368,14 @@ export default class ProjectsService {
     if (!project) throw new Error('Project not found');
 
     const pipelinesDir = path.join(project.path, 'rosetta', 'pipelines');
-    if (!fs.existsSync(pipelinesDir)) return [];
+    const legacyPipelinesDir = path.join(project.path, '.rosetta');
 
-    const entries = await fs.promises.readdir(pipelinesDir);
-    return entries
-      .filter(
-        (f) => (f.endsWith('.yml') || f.endsWith('.yaml')) && f !== 'main.conf',
-      )
-      .map((f) => ({
-        name: f.replace(/\.(yml|yaml)$/, ''),
-        path: path.join(pipelinesDir, f),
-      }));
+    const [current, legacy] = await Promise.all([
+      this.listPipelineFilesInDir(pipelinesDir),
+      this.listPipelineFilesInDir(legacyPipelinesDir),
+    ]);
+
+    const currentNames = new Set(current.map((p) => p.name));
+    return [...current, ...legacy.filter((p) => !currentNames.has(p.name))];
   }
 }

--- a/src/main/services/projects.service.ts
+++ b/src/main/services/projects.service.ts
@@ -20,6 +20,7 @@ import {
 import {
   createNewFile,
   createNewFolder,
+  asyncCreateNewFolder,
   copyPath,
   createZipArchive,
   deleteDirectory,
@@ -952,6 +953,19 @@ export default class ProjectsService {
 
   static createFolder({ filePath, name }: { filePath: string; name: string }) {
     createNewFolder(filePath, name);
+  }
+
+  // Awaitable counterpart to createFolder — use when the folder must exist
+  // on disk before a subsequent write into it (e.g. writing a file right
+  // after creating its parent directory).
+  static async createFolderAsync({
+    filePath,
+    name,
+  }: {
+    filePath: string;
+    name: string;
+  }) {
+    await asyncCreateNewFolder(filePath, name);
   }
 
   static copyPath({ source, target }: { source: string; target: string }) {

--- a/src/main/services/projects.service.ts
+++ b/src/main/services/projects.service.ts
@@ -1351,23 +1351,39 @@ export default class ProjectsService {
   }
 
   /**
-   * List pipeline YAML files in a directory, ignoring non-pipeline yaml
-   * files such as main.conf.
+   * Recursively lists pipeline YAML files under a directory, ignoring
+   * non-pipeline yaml files such as main.conf. `name` is the path relative to
+   * `baseDir` (POSIX-style, extension stripped) so pipelines nested in
+   * subdirectories keep their directory prefix, e.g. `test/test` for
+   * `<baseDir>/test/test.yml`.
    */
   private static async listPipelineFilesInDir(
     dir: string,
+    baseDir: string = dir,
   ): Promise<{ name: string; path: string }[]> {
     if (!fs.existsSync(dir)) return [];
 
-    const entries = await fs.promises.readdir(dir);
-    return entries
-      .filter(
-        (f) => (f.endsWith('.yml') || f.endsWith('.yaml')) && f !== 'main.conf',
-      )
-      .map((f) => ({
-        name: f.replace(/\.(yml|yaml)$/, ''),
-        path: path.join(dir, f),
-      }));
+    const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    const results: { name: string; path: string }[] = [];
+
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        const nested = await this.listPipelineFilesInDir(entryPath, baseDir);
+        results.push(...nested);
+      } else if (
+        (entry.name.endsWith('.yml') || entry.name.endsWith('.yaml')) &&
+        entry.name !== 'main.conf'
+      ) {
+        const relative = path
+          .relative(baseDir, entryPath)
+          .replace(/\\/g, '/')
+          .replace(/\.(yml|yaml)$/, '');
+        results.push({ name: relative, path: entryPath });
+      }
+    }
+
+    return results;
   }
 
   /**

--- a/src/main/services/rosettaCloud.service.ts
+++ b/src/main/services/rosettaCloud.service.ts
@@ -460,7 +460,11 @@ export default class RosettaCloudService {
       throw new Error(`Failed to fetch action status: ${response.status}`);
     }
 
-    return (await response.json()) as CloudPipelineData;
+    const body = await response.json();
+    // TEMP DEBUG — remove once we've confirmed the shape of this response.
+    // eslint-disable-next-line no-console
+    console.log('[getActionStatus] raw response', JSON.stringify(body));
+    return body as CloudPipelineData;
   }
 
   static async validateApiKey(

--- a/src/main/utils/fileHelper.ts
+++ b/src/main/utils/fileHelper.ts
@@ -162,6 +162,18 @@ export const createNewFolder = (parentPath: string, folderName: string) => {
   });
 };
 
+// Like createNewFolder, but actually awaitable: fs.promises.mkdir only
+// resolves once the directory exists, so callers that need to write into
+// the folder immediately after can safely await this instead of racing
+// createNewFolder's fire-and-forget callback.
+export const asyncCreateNewFolder = async (
+  parentPath: string,
+  folderName: string,
+): Promise<void> => {
+  const folderPath = path.join(parentPath, folderName);
+  await fs.promises.mkdir(folderPath, { recursive: true });
+};
+
 // helper functions for file copy
 const copyFile = async (source: string, target: string) => {
   // Normalize the destination: check if target already ends with the basename

--- a/src/renderer/components/fileTreeViewer/TreeNode.tsx
+++ b/src/renderer/components/fileTreeViewer/TreeNode.tsx
@@ -115,8 +115,10 @@ const isPipelineYaml = (filePath: string): boolean => {
   const parts = filePath.replace(/\\/g, '/').split('/');
   const fileName = parts[parts.length - 1] || '';
   const parentDir = parts[parts.length - 2] || '';
+  const grandparentDir = parts[parts.length - 3] || '';
   return (
-    parentDir === '.rosetta' &&
+    parentDir === 'pipelines' &&
+    grandparentDir === 'rosetta' &&
     (fileName.endsWith('.yml') || fileName.endsWith('.yaml')) &&
     fileName !== 'main.conf'
   );

--- a/src/renderer/components/fileTreeViewer/TreeNode.tsx
+++ b/src/renderer/components/fileTreeViewer/TreeNode.tsx
@@ -116,12 +116,15 @@ const isPipelineYaml = (filePath: string): boolean => {
   const fileName = parts[parts.length - 1] || '';
   const parentDir = parts[parts.length - 2] || '';
   const grandparentDir = parts[parts.length - 3] || '';
-  return (
-    parentDir === 'pipelines' &&
-    grandparentDir === 'rosetta' &&
+  const isYaml =
     (fileName.endsWith('.yml') || fileName.endsWith('.yaml')) &&
-    fileName !== 'main.conf'
-  );
+    fileName !== 'main.conf';
+  // Deprecated location, kept for backward compatibility during the
+  // transition to rosetta/pipelines/. Remove once projects have migrated.
+  const isLegacyLocation = parentDir === '.rosetta';
+  const isCurrentLocation =
+    parentDir === 'pipelines' && grandparentDir === 'rosetta';
+  return isYaml && (isLegacyLocation || isCurrentLocation);
 };
 
 export const TreeNode: React.FC<TreeNodeProps> = ({

--- a/src/renderer/components/fileTreeViewer/TreeNode.tsx
+++ b/src/renderer/components/fileTreeViewer/TreeNode.tsx
@@ -114,16 +114,18 @@ interface TreeNodeProps extends NodeRendererProps<FileNode> {
 const isPipelineYaml = (filePath: string): boolean => {
   const parts = filePath.replace(/\\/g, '/').split('/');
   const fileName = parts[parts.length - 1] || '';
-  const parentDir = parts[parts.length - 2] || '';
-  const grandparentDir = parts[parts.length - 3] || '';
+  const dirParts = parts.slice(0, -1);
   const isYaml =
     (fileName.endsWith('.yml') || fileName.endsWith('.yaml')) &&
     fileName !== 'main.conf';
   // Deprecated location, kept for backward compatibility during the
   // transition to rosetta/pipelines/. Remove once projects have migrated.
-  const isLegacyLocation = parentDir === '.rosetta';
-  const isCurrentLocation =
-    parentDir === 'pipelines' && grandparentDir === 'rosetta';
+  // Matches any depth under rosetta/pipelines/ or .rosetta/ so pipelines
+  // nested in subdirectories are still recognized.
+  const isLegacyLocation = dirParts.includes('.rosetta');
+  const isCurrentLocation = dirParts.some(
+    (dir, i) => dir === 'rosetta' && dirParts[i + 1] === 'pipelines',
+  );
   return isYaml && (isLegacyLocation || isCurrentLocation);
 };
 

--- a/src/renderer/components/modals/createPipelineModal/index.tsx
+++ b/src/renderer/components/modals/createPipelineModal/index.tsx
@@ -170,10 +170,10 @@ export const CreatePipelineModal: React.FC<CreatePipelineModalProps> = ({
   const writePipelineFile = async (fileName: string, content: string) => {
     await projectsServices.createFolder({
       filePath: project.path,
-      name: '.rosetta',
+      name: 'rosetta/pipelines',
     });
 
-    const pipelinePath = `${project.path}/.rosetta/${fileName}`;
+    const pipelinePath = `${project.path}/rosetta/pipelines/${fileName}`;
     await projectsServices.saveFileContent({
       path: pipelinePath,
       content,
@@ -407,7 +407,7 @@ export const CreatePipelineModal: React.FC<CreatePipelineModalProps> = ({
                     bgcolor: alpha(theme.palette.common.white, 0.15),
                   }}
                 >
-                  .rosetta/
+                  rosetta/pipelines/
                 </Box>
               </>
             )}
@@ -616,7 +616,7 @@ export const CreatePipelineModal: React.FC<CreatePipelineModalProps> = ({
                             opacity: 0.8,
                           }}
                         >
-                          .rosetta/{template.fileName}
+                          rosetta/pipelines/{template.fileName}
                         </Typography>
                       </Box>
 
@@ -931,7 +931,7 @@ export const CreatePipelineModal: React.FC<CreatePipelineModalProps> = ({
                               opacity: 0.8,
                             }}
                           >
-                            .rosetta/{template.fileName}
+                            rosetta/pipelines/{template.fileName}
                           </Typography>
                         </Box>
                       );

--- a/src/renderer/components/modals/createPipelineModal/index.tsx
+++ b/src/renderer/components/modals/createPipelineModal/index.tsx
@@ -168,7 +168,7 @@ export const CreatePipelineModal: React.FC<CreatePipelineModalProps> = ({
   };
 
   const writePipelineFile = async (fileName: string, content: string) => {
-    await projectsServices.createFolder({
+    await projectsServices.createFolderAsync({
       filePath: project.path,
       name: 'rosetta/pipelines',
     });

--- a/src/renderer/components/modals/pipelineSelectorModal/index.tsx
+++ b/src/renderer/components/modals/pipelineSelectorModal/index.tsx
@@ -136,13 +136,13 @@ export const PipelineSelectorModal: React.FC<PipelineSelectorModalProps> = ({
   const handleCreatePipeline = async () => {
     setIsCreating(true);
     try {
-      // Ensure .rosetta directory exists
+      // Ensure rosetta/pipelines directory exists
       await projectsServices.createFolder({
         filePath: project.path,
-        name: '.rosetta',
+        name: 'rosetta/pipelines',
       });
 
-      const pipelinePath = `${project.path}/.rosetta/pipeline.yml`;
+      const pipelinePath = `${project.path}/rosetta/pipelines/pipeline.yml`;
       await projectsServices.saveFileContent({
         path: pipelinePath,
         content: PIPELINE_TEMPLATE,
@@ -150,7 +150,7 @@ export const PipelineSelectorModal: React.FC<PipelineSelectorModalProps> = ({
 
       await window.electron.ipcRenderer.invoke('git:add', {
         repoPath: project.path,
-        files: ['.rosetta/pipeline.yml'],
+        files: ['rosetta/pipelines/pipeline.yml'],
       });
       await window.electron.ipcRenderer.invoke('git:commit', {
         repoPath: project.path,
@@ -229,9 +229,9 @@ export const PipelineSelectorModal: React.FC<PipelineSelectorModalProps> = ({
             </Typography>
             <Typography variant="body2" color="text.secondary">
               No pipeline configuration files were found under{' '}
-              <code>.rosetta/</code>. A pipeline defines a sequence of steps
-              (e.g., dbt deps, dbt run, dbt test) that will be executed on the
-              cloud.
+              <code>rosetta/pipelines/</code>. A pipeline defines a sequence of
+              steps (e.g., dbt deps, dbt run, dbt test) that will be executed on
+              the cloud.
             </Typography>
             <Button
               variant="contained"
@@ -245,8 +245,8 @@ export const PipelineSelectorModal: React.FC<PipelineSelectorModalProps> = ({
               {isCreating ? 'Creating...' : 'Create Default Pipeline & Push'}
             </Button>
             <Typography variant="caption" color="text.secondary">
-              This will create <code>.rosetta/pipeline.yml</code>, commit, and
-              push it to your remote repository.
+              This will create <code>rosetta/pipelines/pipeline.yml</code>,
+              commit, and push it to your remote repository.
             </Typography>
           </Stack>
         </Paper>

--- a/src/renderer/components/modals/pipelineSelectorModal/index.tsx
+++ b/src/renderer/components/modals/pipelineSelectorModal/index.tsx
@@ -136,8 +136,8 @@ export const PipelineSelectorModal: React.FC<PipelineSelectorModalProps> = ({
   const handleCreatePipeline = async () => {
     setIsCreating(true);
     try {
-      // Ensure rosetta/pipelines directory exists
-      await projectsServices.createFolder({
+      // Ensure rosetta/pipelines directory exists before writing into it
+      await projectsServices.createFolderAsync({
         filePath: project.path,
         name: 'rosetta/pipelines',
       });

--- a/src/renderer/components/modals/pushToCloudModal/index.tsx
+++ b/src/renderer/components/modals/pushToCloudModal/index.tsx
@@ -1637,7 +1637,7 @@ export const PushToCloudModal: React.FC<PushToCloudModalProps> = ({
 
           <Typography variant="body2" color="text.secondary">
             {isPipelineMode
-              ? 'Run a pipeline on the cloud. Pipelines execute a sequence of steps defined in your .rosetta/ directory.'
+              ? 'Run a pipeline on the cloud. Pipelines execute a sequence of steps defined in your rosetta/pipelines/ directory.'
               : 'Run your deployed project on the cloud.'}
           </Typography>
 

--- a/src/renderer/components/pipelineView/PipelineView.tsx
+++ b/src/renderer/components/pipelineView/PipelineView.tsx
@@ -98,10 +98,14 @@ export const PipelineView: React.FC<PipelineViewProps> = ({
     return applyStatuses(config.jobs, actionStatus);
   }, [config, actionStatus]);
 
-  // Derive a coarse run state from the matched steps so the header chip can
-  // show something meaningful without a separate /actions/[id] round-trip.
+  // Prefer the overall container status when the API provides one — steps
+  // are updated conditionally and may never all reach a terminal state even
+  // after the run finishes, so deriving from steps alone can get stuck.
+  // Fall back to deriving from steps only for responses that omit it.
   const derivedRunState: CloudActionStatus | null = React.useMemo(() => {
-    if (!actionId || !actionStatus?.steps?.length) return null;
+    if (!actionId || !actionStatus) return null;
+    if (actionStatus.status) return actionStatus.status;
+    if (!actionStatus.steps?.length) return null;
     const statuses = actionStatus.steps.map((s) => s.status);
     if (statuses.includes('failed')) return 'FAILED';
     if (statuses.includes('running')) return 'RUNNING';

--- a/src/renderer/components/pipelineView/parsePipelineConfig.ts
+++ b/src/renderer/components/pipelineView/parsePipelineConfig.ts
@@ -49,16 +49,23 @@ export const LEGACY_PIPELINE_CONFIG_DIR = '.rosetta';
 export function isPipelineFile(filePath: string): boolean {
   const parts = filePath.replace(/\\/g, '/').split('/');
   const fileName = parts[parts.length - 1];
-  const dirName = parts[parts.length - 2];
-  const parentDirName = parts[parts.length - 3];
-  if (dirName === LEGACY_PIPELINE_CONFIG_DIR) {
-    return fileName.endsWith('.yml') && fileName !== 'main.conf';
-  }
-  return (
-    dirName === PIPELINE_CONFIG_DIR &&
-    parentDirName === PIPELINE_CONFIG_PARENT_DIR &&
-    fileName.endsWith('.yml')
+  const dirParts = parts.slice(0, -1);
+
+  const isYaml =
+    (fileName.endsWith('.yml') || fileName.endsWith('.yaml')) &&
+    fileName !== 'main.conf';
+  if (!isYaml) return false;
+
+  // Matches any depth under rosetta/pipelines/ or .rosetta/, not just files
+  // directly inside them, so pipelines nested in subdirectories are still
+  // recognized.
+  const isLegacyLocation = dirParts.includes(LEGACY_PIPELINE_CONFIG_DIR);
+  const isCurrentLocation = dirParts.some(
+    (dir, i) =>
+      dir === PIPELINE_CONFIG_PARENT_DIR &&
+      dirParts[i + 1] === PIPELINE_CONFIG_DIR,
   );
+  return isLegacyLocation || isCurrentLocation;
 }
 
 export const PIPELINE_CONFIG_TEMPLATE = `name: "CI"

--- a/src/renderer/components/pipelineView/parsePipelineConfig.ts
+++ b/src/renderer/components/pipelineView/parsePipelineConfig.ts
@@ -42,12 +42,18 @@ export function parsePipelineConfig(content: string): PipelineConfig | null {
 export const PIPELINE_CONFIG_FILENAME = 'pipeline.yml';
 export const PIPELINE_CONFIG_PARENT_DIR = 'rosetta';
 export const PIPELINE_CONFIG_DIR = 'pipelines';
+// Deprecated location, kept for backward compatibility during the transition
+// to rosetta/pipelines/. Remove once existing projects have migrated.
+export const LEGACY_PIPELINE_CONFIG_DIR = '.rosetta';
 
 export function isPipelineFile(filePath: string): boolean {
   const parts = filePath.replace(/\\/g, '/').split('/');
   const fileName = parts[parts.length - 1];
   const dirName = parts[parts.length - 2];
   const parentDirName = parts[parts.length - 3];
+  if (dirName === LEGACY_PIPELINE_CONFIG_DIR) {
+    return fileName.endsWith('.yml') && fileName !== 'main.conf';
+  }
   return (
     dirName === PIPELINE_CONFIG_DIR &&
     parentDirName === PIPELINE_CONFIG_PARENT_DIR &&

--- a/src/renderer/components/pipelineView/parsePipelineConfig.ts
+++ b/src/renderer/components/pipelineView/parsePipelineConfig.ts
@@ -40,13 +40,19 @@ export function parsePipelineConfig(content: string): PipelineConfig | null {
 
 // Filename detection
 export const PIPELINE_CONFIG_FILENAME = 'pipeline.yml';
-export const PIPELINE_CONFIG_DIR = '.rosetta';
+export const PIPELINE_CONFIG_PARENT_DIR = 'rosetta';
+export const PIPELINE_CONFIG_DIR = 'pipelines';
 
 export function isPipelineFile(filePath: string): boolean {
   const parts = filePath.replace(/\\/g, '/').split('/');
   const fileName = parts[parts.length - 1];
   const dirName = parts[parts.length - 2];
-  return dirName === PIPELINE_CONFIG_DIR && fileName.endsWith('.yml');
+  const parentDirName = parts[parts.length - 3];
+  return (
+    dirName === PIPELINE_CONFIG_DIR &&
+    parentDirName === PIPELINE_CONFIG_PARENT_DIR &&
+    fileName.endsWith('.yml')
+  );
 }
 
 export const PIPELINE_CONFIG_TEMPLATE = `name: "CI"

--- a/src/renderer/controllers/rosettaCloud.controller.ts
+++ b/src/renderer/controllers/rosettaCloud.controller.ts
@@ -19,7 +19,11 @@ import {
   UseAuthLoginResult,
   UseAuthLogoutResult,
 } from '../../types/apiKey';
-import { CloudLogEntry, CloudPipelineData } from '../../types/cloudAction';
+import {
+  CloudLogEntry,
+  CloudPipelineData,
+  isTerminalActionStatus,
+} from '../../types/cloudAction';
 import { rosettaCloudServices } from '../services';
 import { QUERY_KEYS } from '../config/constants';
 
@@ -204,9 +208,12 @@ export const useCloudActionStatus = (
         ? rosettaCloudServices.getActionStatus(actionId)
         : Promise.resolve(null),
     enabled: !!actionId,
-    // Keep polling while at least one step is still pending/running. Stop once
-    // every step has settled into a terminal state.
+    // Stop polling once the overall container status is terminal. Steps are
+    // updated conditionally and may never all settle even after the run
+    // finishes, so step statuses alone aren't a reliable stop condition.
     refetchInterval: (data) => {
+      if (data?.status)
+        return isTerminalActionStatus(data.status) ? false : 3000;
       if (!data?.steps?.length) return 3000;
       const stillActive = data.steps.some(
         (s) =>
@@ -223,6 +230,7 @@ export const useCloudActionStatus = (
 const isActionFinishedFromStatus = (
   status: CloudPipelineData | null | undefined,
 ): boolean => {
+  if (status?.status) return isTerminalActionStatus(status.status);
   if (!status?.steps?.length) return false;
   return status.steps.every(
     (s) =>

--- a/src/renderer/screens/projectDetails/index.tsx
+++ b/src/renderer/screens/projectDetails/index.tsx
@@ -127,6 +127,34 @@ const VerticalSash = (_: number, active: boolean) => (
   </div>
 );
 
+/**
+ * Resolves a pipeline file's identifier relative to whichever pipelines base
+ * directory it lives under (`rosetta/pipelines/` current, `.rosetta/`
+ * legacy), extension stripped — matching the `name` the main process reports
+ * from `ProjectsService.listPipelines`. Falls back to the bare filename if
+ * the file isn't under a known base dir. This is what must be sent as
+ * `PIPELINE_FILE` and used as the `pipelineRuns` lookup key so nested
+ * pipelines don't collide with same-named pipelines in other folders.
+ */
+const getPipelineRelativeName = (
+  filePath: string,
+  projectPath: string,
+): string => {
+  const normalizedFile = filePath.replace(/\\/g, '/');
+  const normalizedProject = projectPath.replace(/\\/g, '/').replace(/\/$/, '');
+  const baseDirs = [
+    `${normalizedProject}/rosetta/pipelines/`,
+    `${normalizedProject}/.rosetta/`,
+  ];
+
+  const base = baseDirs.find((dir) => normalizedFile.startsWith(dir));
+  const relative = base
+    ? normalizedFile.slice(base.length)
+    : (normalizedFile.split('/').pop() ?? normalizedFile);
+
+  return relative.replace(/\.(yml|yaml)$/, '');
+};
+
 const ProjectDetails: React.FC = () => {
   const navigate = useNavigate();
   const [verticalSizes, setVerticalSizes] = React.useState<(number | string)[]>(
@@ -216,17 +244,16 @@ const ProjectDetails: React.FC = () => {
   const [pipelineCloudModal, setPipelineCloudModal] = React.useState(false);
   const theme = useTheme();
 
-  const handleRunPipelineFile = React.useCallback((filePath: string) => {
-    // Extract pipeline name from path (filename without extension)
-    const name =
-      filePath
-        .replace(/\\/g, '/')
-        .split('/')
-        .pop()
-        ?.replace(/\.(yml|yaml)$/, '') || '';
-    setPipelineRunArgs(`--pipeline_name ${name}`);
-    setPipelineCloudModal(true);
-  }, []);
+  const handleRunPipelineFile = React.useCallback(
+    (filePath: string) => {
+      const name = project?.path
+        ? getPipelineRelativeName(filePath, project.path)
+        : '';
+      setPipelineRunArgs(`--pipeline_name ${name}`);
+      setPipelineCloudModal(true);
+    },
+    [project?.path],
+  );
 
   // Pipeline tab support — derive state from the currently active tab
   const activePipelineFilePath = React.useMemo(() => {
@@ -245,13 +272,26 @@ const ProjectDetails: React.FC = () => {
     return parts[parts.length - 1] || null;
   }, [activePipelineFilePath]);
 
-  const recordedPipelineActionId = activePipelineBasename
-    ? (project?.pipelineRuns?.[activePipelineBasename] ?? null)
+  // Identifier matching the PIPELINE_FILE sent to the cloud and the key used
+  // in project.pipelineRuns (relative to the pipelines base dir, e.g.
+  // `test/test.yml`) — must NOT be reduced to just the basename, or nested
+  // pipelines collide with same-named pipelines in other folders.
+  const activePipelineFile = React.useMemo(() => {
+    if (!activePipelineFilePath || !project?.path) return null;
+    const relativeName = getPipelineRelativeName(
+      activePipelineFilePath,
+      project.path,
+    );
+    return relativeName ? `${relativeName}.yml` : null;
+  }, [activePipelineFilePath, project?.path]);
+
+  const recordedPipelineActionId = activePipelineFile
+    ? (project?.pipelineRuns?.[activePipelineFile] ?? null)
     : null;
 
   const activePipelineActionId = usePipelineActionId(
     project?.externalId ? project?.id : null,
-    activePipelineBasename,
+    activePipelineFile,
     recordedPipelineActionId,
   );
 

--- a/src/renderer/services/projects.service.ts
+++ b/src/renderer/services/projects.service.ts
@@ -199,6 +199,19 @@ export const createFolder = async (body: {
   return data;
 };
 
+// Awaitable counterpart to createFolder — resolves only once the folder
+// actually exists on disk, safe to use right before writing a file into it.
+export const createFolderAsync = async (body: {
+  filePath: string;
+  name: string;
+}): Promise<void> => {
+  const { data } = await client.post<{
+    filePath: string;
+    name: string;
+  }>('project:createFolderAsync', body);
+  return data;
+};
+
 export const copyPath = async (body: {
   source: string;
   target: string;

--- a/src/types/cloudAction.ts
+++ b/src/types/cloudAction.ts
@@ -41,6 +41,11 @@ export interface CloudPipelineStep {
 }
 
 export interface CloudPipelineData {
+  // Overall CI/CD container status — authoritative for whether the run is
+  // done. Steps are updated conditionally and may not all reach a terminal
+  // state even after the run finishes, so this must take priority over any
+  // status derived from `steps`.
+  status?: CloudActionStatus;
   steps: CloudPipelineStep[];
   metadata?: {
     job_name?: string;

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -58,6 +58,7 @@ export type ProjectChannels =
   | 'project:createFile'
   | 'project:deleteItem'
   | 'project:createFolder'
+  | 'project:createFolderAsync'
   | 'project:copyPath'
   | 'project:select'
   | 'project:selected'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipelines are now created and stored in `rosetta/pipelines/`.
  * Pipeline discovery supports nested YAML files in both current and legacy locations.
  * Existing legacy pipelines remain supported, with current-location files prioritized when names conflict.
  * Folder creation completes reliably before new pipelines appear.
  * Nested pipelines retain their relative paths during execution and cloud tracking.

* **Bug Fixes**
  * Missing pipeline directories are handled gracefully.
  * `main.conf` and non-YAML files are excluded from pipeline detection.
  * Cloud progress and completion now use the overall action status when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->