### PR TITLE
fix:  timeout safety for Rosetta dbt commands

### DIFF
--- a/src/renderer/components/dbtModelButtons/ProjectDbtSplitButton.tsx
+++ b/src/renderer/components/dbtModelButtons/ProjectDbtSplitButton.tsx
@@ -402,13 +402,16 @@ export const ProjectDbtSplitButton: React.FC<ProjectDbtSplitButtonProps> = ({
           path={rawPath}
           project={project}
           processCallback={async (updatedPath) => {
-            onBeforeExecute?.();
-            await rosettaDbt(project, {
-              command: 'extract',
-              commandType: CommandType.DBTNext,
-              arguments: new Map([['-o', updatedPath]]),
-            } as Command);
-            setOpenRawLayerModal(false);
+            try {
+              onBeforeExecute?.();
+              await rosettaDbt(project, {
+                command: 'extract',
+                commandType: CommandType.DBTNext,
+                arguments: new Map([['-o', updatedPath]]),
+              } as Command);
+            } finally {
+              setOpenRawLayerModal(false);
+            }
           }}
         />
       )}
@@ -427,13 +430,16 @@ export const ProjectDbtSplitButton: React.FC<ProjectDbtSplitButtonProps> = ({
               });
               args.set(' ', command);
             }
-            onBeforeExecute?.();
-            await rosettaDbt(project, {
-              command: 'staging',
-              commandType: CommandType.DBTNext,
-              arguments: args,
-            } as Command);
-            setStagingModal(false);
+            try {
+              onBeforeExecute?.();
+              await rosettaDbt(project, {
+                command: 'staging',
+                commandType: CommandType.DBTNext,
+                arguments: args,
+              } as Command);
+            } finally {
+              setStagingModal(false);
+            }
           }}
         />
       )}
@@ -452,13 +458,16 @@ export const ProjectDbtSplitButton: React.FC<ProjectDbtSplitButtonProps> = ({
               });
               args.set(' ', command);
             }
-            onBeforeExecute?.();
-            await rosettaDbt(project, {
-              commandType: CommandType.DBTNext,
-              command: 'incremental',
-              arguments: args,
-            } as Command);
-            setIncrementalModal(false);
+            try {
+              onBeforeExecute?.();
+              await rosettaDbt(project, {
+                commandType: CommandType.DBTNext,
+                command: 'incremental',
+                arguments: args,
+              } as Command);
+            } finally {
+              setIncrementalModal(false);
+            }
           }}
         />
       )}

--- a/src/renderer/components/modals/incrementalModal/index.tsx
+++ b/src/renderer/components/modals/incrementalModal/index.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from '@mui/material';
 import React from 'react';
+import { toast } from 'react-toastify';
 import { projectsServices } from '../../../services';
 import { useUpdateProject } from '../../../controllers';
 import { FileNode, Project } from '../../../../types/backend';
@@ -417,6 +418,11 @@ export const IncrementalModal: React.FC<Props> = ({
                 incrementalDir: updatedPath,
               });
               await processCallback(updatedPath, allSelectedFiles);
+            } catch (err) {
+              // eslint-disable-next-line no-console
+              console.error(err);
+              toast.error('Failed to generate incremental layer');
+              throw err;
             } finally {
               setLoading(false);
             }

--- a/src/renderer/components/modals/incrementalModal/index.tsx
+++ b/src/renderer/components/modals/incrementalModal/index.tsx
@@ -22,7 +22,7 @@ import { SelectableFileTree } from '../../selectableFileTree';
 type Props = {
   isOpen: boolean;
   onClose: () => void;
-  processCallback: (path: string, selectedFiles: string[]) => void;
+  processCallback: (path: string, selectedFiles: string[]) => Promise<void>;
   path: string;
   project: Project;
 };
@@ -411,11 +411,15 @@ export const IncrementalModal: React.FC<Props> = ({
           variant="contained"
           onClick={async () => {
             setLoading(true);
-            await updateProject.mutateAsync({
-              ...project,
-              incrementalDir: updatedPath,
-            });
-            processCallback(updatedPath, allSelectedFiles);
+            try {
+              await updateProject.mutateAsync({
+                ...project,
+                incrementalDir: updatedPath,
+              });
+              await processCallback(updatedPath, allSelectedFiles);
+            } finally {
+              setLoading(false);
+            }
           }}
           disabled={totalSelectedItems === 0 || loading}
           sx={{

--- a/src/renderer/components/modals/rawLayerModal/index.tsx
+++ b/src/renderer/components/modals/rawLayerModal/index.tsx
@@ -12,6 +12,7 @@ import {
   InputAdornment,
 } from '@mui/material';
 import React from 'react';
+import { toast } from 'react-toastify';
 import { projectsServices } from '../../../services';
 import { useUpdateProject } from '../../../controllers';
 import { Project } from '../../../../types/backend';
@@ -144,6 +145,11 @@ export const RawLayerModal: React.FC<Props> = ({
                 rawLayerDir: updatedPath,
               });
               await processCallback(updatedPath);
+            } catch (err) {
+              // eslint-disable-next-line no-console
+              console.error(err);
+              toast.error('Failed to generate raw layer');
+              throw err;
             } finally {
               setLoading(false);
             }

--- a/src/renderer/components/modals/rawLayerModal/index.tsx
+++ b/src/renderer/components/modals/rawLayerModal/index.tsx
@@ -19,7 +19,7 @@ import { Project } from '../../../../types/backend';
 type Props = {
   isOpen: boolean;
   onClose: () => void;
-  processCallback: (path: string) => void;
+  processCallback: (path: string) => Promise<void>;
   path: string;
   project: Project;
 };
@@ -138,11 +138,15 @@ export const RawLayerModal: React.FC<Props> = ({
           variant="contained"
           onClick={async () => {
             setLoading(true);
-            await updateProject.mutateAsync({
-              ...project,
-              rawLayerDir: updatedPath,
-            });
-            processCallback(updatedPath);
+            try {
+              await updateProject.mutateAsync({
+                ...project,
+                rawLayerDir: updatedPath,
+              });
+              await processCallback(updatedPath);
+            } finally {
+              setLoading(false);
+            }
           }}
           disabled={loading}
           sx={{

--- a/src/renderer/components/modals/stagingModal/index.tsx
+++ b/src/renderer/components/modals/stagingModal/index.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from '@mui/material';
 import React from 'react';
+import { toast } from 'react-toastify';
 import { projectsServices } from '../../../services';
 import { useUpdateProject } from '../../../controllers';
 import { FileNode, Project } from '../../../../types/backend';
@@ -413,6 +414,11 @@ export const StagingModal: React.FC<Props> = ({
                 stagingDir: updatedPath,
               });
               await processCallback(updatedPath, allSelectedFiles);
+            } catch (err) {
+              // eslint-disable-next-line no-console
+              console.error(err);
+              toast.error('Failed to generate staging layer');
+              throw err;
             } finally {
               setLoading(false);
             }

--- a/src/renderer/components/modals/stagingModal/index.tsx
+++ b/src/renderer/components/modals/stagingModal/index.tsx
@@ -22,7 +22,7 @@ import { SelectableFileTree } from '../../selectableFileTree';
 type Props = {
   isOpen: boolean;
   onClose: () => void;
-  processCallback: (path: string, selectedFiles: string[]) => void;
+  processCallback: (path: string, selectedFiles: string[]) => Promise<void>;
   path: string;
   project: Project;
 };
@@ -407,11 +407,15 @@ export const StagingModal: React.FC<Props> = ({
           variant="contained"
           onClick={async () => {
             setLoading(true);
-            await updateProject.mutateAsync({
-              ...project,
-              stagingDir: updatedPath,
-            });
-            processCallback(updatedPath, allSelectedFiles);
+            try {
+              await updateProject.mutateAsync({
+                ...project,
+                stagingDir: updatedPath,
+              });
+              await processCallback(updatedPath, allSelectedFiles);
+            } finally {
+              setLoading(false);
+            }
           }}
           disabled={totalSelectedItems === 0 || loading}
           sx={{

--- a/src/renderer/hooks/useRosettaDBT.ts
+++ b/src/renderer/hooks/useRosettaDBT.ts
@@ -126,11 +126,15 @@ const useRosettaDBT = (successCallback: () => Promise<void>) => {
 
         const openaiKey = await getOpenAIKey();
         if (openaiKey) {
-          setEnvVariables.mutate({
-            key: 'openai-api-key',
-            value: openaiKey,
-          });
+          envPromises.push(
+            setEnvVariables.mutateAsync({
+              key: 'openai-api-key',
+              value: openaiKey,
+            }),
+          );
         }
+
+        await Promise.all(envPromises);
 
         // 2-minute safety net — enough for large schema extracts;
         // the try/catch recovers cleanly if this fires

--- a/src/renderer/hooks/useRosettaDBT.ts
+++ b/src/renderer/hooks/useRosettaDBT.ts
@@ -171,6 +171,10 @@ const useRosettaDBT = (successCallback: () => Promise<void>) => {
         });
       }
 
+      // 2-minute safety net — enough for large schema extracts;
+      // the try/catch recovers cleanly if this fires
+      const ROSETTA_TIMEOUT_MS = 2 * 60 * 1000;
+
       if (!project.isExtracted) {
         try {
           const compiledCommand = await compileCommand(project, settings, {
@@ -181,7 +185,7 @@ const useRosettaDBT = (successCallback: () => Promise<void>) => {
               `${project.rosettaConnection?.name}`,
             ),
           } as Command);
-          await runCommand(compiledCommand);
+          await runCommand(compiledCommand, undefined, ROSETTA_TIMEOUT_MS);
           await projectsServices.updateProject({
             ...project,
             isExtracted: true,
@@ -193,9 +197,21 @@ const useRosettaDBT = (successCallback: () => Promise<void>) => {
           return;
         }
       }
-      const compiledCommand = await compileCommand(project, settings, command);
-      await runCommand(compiledCommand);
-      setIsSuccess(true);
+
+      try {
+        const compiledCommand = await compileCommand(
+          project,
+          settings,
+          command,
+        );
+        await runCommand(compiledCommand, undefined, ROSETTA_TIMEOUT_MS);
+        setIsSuccess(true);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+        toast.error('Rosetta dbt command failed');
+        setIsRunning(false);
+      }
     },
     isRunning,
   };

--- a/src/renderer/hooks/useRosettaDBT.ts
+++ b/src/renderer/hooks/useRosettaDBT.ts
@@ -13,7 +13,7 @@ import { compileCommand } from '../helpers/utils';
 
 const useRosettaDBT = (successCallback: () => Promise<void>) => {
   const { data: settings } = useGetSettings();
-  const { error, runCommand } = useCli();
+  const { runCommand } = useCli();
   const {
     getDatabaseUsername,
     getDatabasePassword,
@@ -22,194 +22,173 @@ const useRosettaDBT = (successCallback: () => Promise<void>) => {
     getConnectionField,
   } = useSecureStorage();
   const setEnvVariables = useSetConnectionEnvVariable();
-  const [isSuccess, setIsSuccess] = React.useState(false);
   const [isRunning, setIsRunning] = React.useState(false);
   const { data: connections = [] } = useGetConnections(true);
 
-  React.useEffect(() => {
-    let isCancelled = false;
-
-    const resetState = () => {
-      setIsRunning(false);
-      setIsSuccess(false);
-    };
-
-    if (!isRunning) {
-      return () => {
-        isCancelled = true;
-      };
-    }
-
-    if (error.length > 0) {
-      toast.error('Rosetta dbt command failed');
-      resetState();
-      return () => {
-        isCancelled = true;
-      };
-    }
-
-    if (isSuccess) {
-      const handleSuccess = async () => {
-        await successCallback();
-        if (!isCancelled) {
-          toast.success('Rosetta dbt completed successfully');
-          resetState();
-        }
-      };
-      handleSuccess();
-    }
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [isSuccess, error, isRunning, successCallback]);
-
   return {
     fn: async (project: Project, command: Command) => {
-      setIsSuccess(false);
       setIsRunning(true);
-      const connection = connections.find((c) => c.id === project.connectionId);
-      if (!connection) {
-        toast.error(
-          'No database connection configured for this project. Please add a connection first.',
+      try {
+        const connection = connections.find(
+          (c) => c.id === project.connectionId,
         );
-        setIsRunning(false);
-        setIsSuccess(false);
-        return;
-      }
-      // Set environment variables for the project
-      const connectionName = connection.connection.name;
-      const conn = connection.connection;
-      const [username, password, token, bigQueryKey] = await Promise.all([
-        getDatabaseUsername(connectionName),
-        getDatabasePassword(connectionName),
-        getDatabaseToken(connectionName),
-        getBigQueryServiceAccountKey(connectionName),
-      ]);
-
-      const envPromises = [];
-      if (username) {
-        envPromises.push(
-          setEnvVariables.mutateAsync({
-            key: `db-user-${connectionName}`,
-            value: username || '',
-          }),
-        );
-      }
-      if (password) {
-        envPromises.push(
-          setEnvVariables.mutateAsync({
-            key: `db-password-${connectionName}`,
-            value: password || '',
-          }),
-        );
-      }
-      if (token) {
-        envPromises.push(
-          setEnvVariables.mutateAsync({
-            key: `db-token-${connectionName}`,
-            value: token || '',
-          }),
-        );
-      }
-      if (bigQueryKey) {
-        envPromises.push(
-          setEnvVariables.mutateAsync({
-            key: `db-bigquery-${connectionName}`,
-            value: bigQueryKey,
-          }),
-        );
-      }
-
-      // Set connection-specific fields based on type
-      const fieldMap: Record<string, string[]> = {
-        postgres: ['host', 'port', 'dbname', 'schema'],
-        redshift: ['host', 'port', 'dbname', 'schema'],
-        snowflake: ['account', 'warehouse', 'dbname', 'schema', 'role'],
-        bigquery: ['project', 'dataset'],
-        databricks: ['host', 'httppath', 'catalog', 'schema'],
-        kinetica: ['host', 'port', 'dbname', 'schema'],
-      };
-
-      const c = conn as any;
-      const getFieldValue = (field: string): string | undefined => {
-        const valueMap: Record<string, string | undefined> = {
-          host: c.host ? String(c.host) : undefined,
-          port: c.port ? String(c.port) : undefined,
-          dbname: c.database,
-          schema: c.schema,
-          account: c.account,
-          warehouse: c.warehouse,
-          role: c.role,
-          project: c.project,
-          dataset: c.dataset || c.schema,
-          httppath: c.httpPath,
-          catalog: c.database,
-        };
-        return valueMap[field];
-      };
-
-      const fields = fieldMap[conn.type] || [];
-      const fieldPromises = fields.map(async (field) => {
-        const stored = await getConnectionField(field, connectionName);
-        const value = stored || getFieldValue(field);
-        if (value) {
-          return setEnvVariables.mutateAsync({
-            key: `db-${field}-${connectionName}`,
-            value,
-          });
-        }
-        return undefined;
-      });
-      envPromises.push(...fieldPromises);
-
-      const openaiKey = await getOpenAIKey();
-      if (openaiKey) {
-        setEnvVariables.mutate({
-          key: 'openai-api-key',
-          value: openaiKey,
-        });
-      }
-
-      // 2-minute safety net — enough for large schema extracts;
-      // the try/catch recovers cleanly if this fires
-      const ROSETTA_TIMEOUT_MS = 2 * 60 * 1000;
-
-      if (!project.isExtracted) {
-        try {
-          const compiledCommand = await compileCommand(project, settings, {
-            commandType: CommandType.Rosetta,
-            command: 'extract',
-            arguments: new Map<string, string | number>().set(
-              '-s',
-              `${project.rosettaConnection?.name}`,
-            ),
-          } as Command);
-          await runCommand(compiledCommand, undefined, ROSETTA_TIMEOUT_MS);
-          await projectsServices.updateProject({
-            ...project,
-            isExtracted: true,
-          });
-          toast.info('Schema extracted, now generating dbt...');
-        } catch (err) {
-          toast.error('Schema extraction failed');
-          setIsRunning(false);
+        if (!connection) {
+          toast.error(
+            'No database connection configured for this project. Please add a connection first.',
+          );
           return;
         }
-      }
+        // Set environment variables for the project
+        const connectionName = connection.connection.name;
+        const conn = connection.connection;
+        const [username, password, token, bigQueryKey] = await Promise.all([
+          getDatabaseUsername(connectionName),
+          getDatabasePassword(connectionName),
+          getDatabaseToken(connectionName),
+          getBigQueryServiceAccountKey(connectionName),
+        ]);
 
-      try {
-        const compiledCommand = await compileCommand(
-          project,
-          settings,
-          command,
-        );
-        await runCommand(compiledCommand, undefined, ROSETTA_TIMEOUT_MS);
-        setIsSuccess(true);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(err);
-        toast.error('Rosetta dbt command failed');
+        const envPromises = [];
+        if (username) {
+          envPromises.push(
+            setEnvVariables.mutateAsync({
+              key: `db-user-${connectionName}`,
+              value: username || '',
+            }),
+          );
+        }
+        if (password) {
+          envPromises.push(
+            setEnvVariables.mutateAsync({
+              key: `db-password-${connectionName}`,
+              value: password || '',
+            }),
+          );
+        }
+        if (token) {
+          envPromises.push(
+            setEnvVariables.mutateAsync({
+              key: `db-token-${connectionName}`,
+              value: token || '',
+            }),
+          );
+        }
+        if (bigQueryKey) {
+          envPromises.push(
+            setEnvVariables.mutateAsync({
+              key: `db-bigquery-${connectionName}`,
+              value: bigQueryKey,
+            }),
+          );
+        }
+
+        // Set connection-specific fields based on type
+        const fieldMap: Record<string, string[]> = {
+          postgres: ['host', 'port', 'dbname', 'schema'],
+          redshift: ['host', 'port', 'dbname', 'schema'],
+          snowflake: ['account', 'warehouse', 'dbname', 'schema', 'role'],
+          bigquery: ['project', 'dataset'],
+          databricks: ['host', 'httppath', 'catalog', 'schema'],
+          kinetica: ['host', 'port', 'dbname', 'schema'],
+        };
+
+        const c = conn as any;
+        const getFieldValue = (field: string): string | undefined => {
+          const valueMap: Record<string, string | undefined> = {
+            host: c.host ? String(c.host) : undefined,
+            port: c.port ? String(c.port) : undefined,
+            dbname: c.database,
+            schema: c.schema,
+            account: c.account,
+            warehouse: c.warehouse,
+            role: c.role,
+            project: c.project,
+            dataset: c.dataset || c.schema,
+            httppath: c.httpPath,
+            catalog: c.database,
+          };
+          return valueMap[field];
+        };
+
+        const fields = fieldMap[conn.type] || [];
+        const fieldPromises = fields.map(async (field) => {
+          const stored = await getConnectionField(field, connectionName);
+          const value = stored || getFieldValue(field);
+          if (value) {
+            return setEnvVariables.mutateAsync({
+              key: `db-${field}-${connectionName}`,
+              value,
+            });
+          }
+          return undefined;
+        });
+        envPromises.push(...fieldPromises);
+
+        const openaiKey = await getOpenAIKey();
+        if (openaiKey) {
+          setEnvVariables.mutate({
+            key: 'openai-api-key',
+            value: openaiKey,
+          });
+        }
+
+        // 2-minute safety net — enough for large schema extracts;
+        // the try/catch recovers cleanly if this fires
+        const ROSETTA_TIMEOUT_MS = 2 * 60 * 1000;
+
+        if (!project.isExtracted) {
+          try {
+            const compiledCommand = await compileCommand(project, settings, {
+              commandType: CommandType.Rosetta,
+              command: 'extract',
+              arguments: new Map<string, string | number>().set(
+                '-s',
+                `${project.rosettaConnection?.name}`,
+              ),
+            } as Command);
+            const result = await runCommand(
+              compiledCommand,
+              undefined,
+              ROSETTA_TIMEOUT_MS,
+            );
+            if (result.exitCode !== 0 && result.exitCode !== null) {
+              throw new Error(
+                `Command failed with exit code ${result.exitCode}`,
+              );
+            }
+            await projectsServices.updateProject({
+              ...project,
+              isExtracted: true,
+            });
+            toast.info('Schema extracted, now generating dbt...');
+          } catch (err) {
+            toast.error('Schema extraction failed');
+            return;
+          }
+        }
+
+        try {
+          const compiledCommand = await compileCommand(
+            project,
+            settings,
+            command,
+          );
+          const result = await runCommand(
+            compiledCommand,
+            undefined,
+            ROSETTA_TIMEOUT_MS,
+          );
+          if (result.exitCode !== 0 && result.exitCode !== null) {
+            throw new Error(`Command failed with exit code ${result.exitCode}`);
+          }
+          await successCallback();
+          toast.success('Rosetta dbt completed successfully');
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error(err);
+          toast.error('Rosetta dbt command failed');
+        }
+      } finally {
         setIsRunning(false);
       }
     },


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Modal dialogs now close reliably after Raw Layer, Staging, and Incremental/Enhanced Layer operations, even when processing encounters an error.
  - Loading indicators are consistently cleared after generation attempts, preventing dialogs from appearing stuck.
  - Rosetta DBT operations now time out after two minutes and provide clear success or failure notifications.
  - Failed generation attempts reset correctly, allowing users to try again without restarting the application.
  - Errors during layer generation are reported with notifications while preserving reliable cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->