### PR TITLE
feat(sqlite): add standalone SQLite connection support

### DIFF
--- a/assets/connectionIcons/index.ts
+++ b/assets/connectionIcons/index.ts
@@ -72,6 +72,7 @@ const obj: { images: Image } = {
     databricks,
     duckdb,
     ducklake,
+    sqlite,
     mysql,
     oracle,
     db2,

--- a/src/main/services/connectors.service.ts
+++ b/src/main/services/connectors.service.ts
@@ -22,6 +22,7 @@ import {
   RedshiftConnection,
   RosettaConnection,
   SnowflakeConnection,
+  SQLiteConnection,
 } from '../../types/backend';
 import { loadDatabaseFile, updateDatabase } from '../utils/fileHelper';
 import { ProjectsService } from './index';
@@ -41,7 +42,10 @@ import {
   testRedshiftConnection,
   testSnowflakeConnection,
   testKineticaConnection,
+  testSQLiteConnection,
   executeKineticaQuery,
+  executeSQLiteQuery,
+  extractSQLiteSchema,
 } from '../utils/connectors';
 import SecureStorageService from './secureStorage.service';
 import { CloudConnection, RecentItem } from '../../types/frontend';
@@ -181,6 +185,11 @@ export default class ConnectorsService {
           conn1.schema === (conn2 as DuckDBConnection).schema
         );
 
+      case 'sqlite':
+        return (
+          conn1.database_path === (conn2 as SQLiteConnection).database_path
+        );
+
       case 'ducklake':
         return (
           conn1.instanceId === (conn2 as DuckLakeConnectionConfig).instanceId
@@ -295,6 +304,15 @@ export default class ConnectorsService {
         // Extract filename from path if available
         const fileName = path.basename(duckConn.database_path, '.duckdb');
         baseName = fileName || duckConn.name;
+        break;
+      }
+      case 'sqlite': {
+        const sqliteConnection = connection as SQLiteConnection;
+        baseName =
+          path.basename(
+            sqliteConnection.database_path,
+            path.extname(sqliteConnection.database_path),
+          ) || sqliteConnection.name;
         break;
       }
       case 'postgres':
@@ -532,6 +550,10 @@ export default class ConnectorsService {
       throw new Error('Connection not found!');
     }
 
+    if (projectIndex !== -1 && connection.type === 'sqlite') {
+      throw new Error('SQLite connections cannot be used by dbt projects');
+    }
+
     await this.validateConnection(connection);
 
     if (!connectionId) {
@@ -622,6 +644,8 @@ export default class ConnectorsService {
 
     connections[connectionIndex] = connection;
     await updateDatabase<'connections'>('connections', connections);
+
+    if (connection.connection.type === 'sqlite') return;
 
     // Find all projects using this connection and update their config files
     const projects = await ProjectsService.loadProjects();
@@ -757,6 +781,8 @@ export default class ConnectorsService {
         return testDatabricksConnection(connection);
       case 'duckdb':
         return testDuckDBConnection(connection);
+      case 'sqlite':
+        return testSQLiteConnection(connection);
       case 'ducklake':
         // DuckLake connection test - validate instance exists
         try {
@@ -873,6 +899,9 @@ export default class ConnectorsService {
             query,
             registerCancel,
           );
+          break;
+        case 'sqlite':
+          response = executeSQLiteQuery(connection, query);
           break;
         case 'redshift':
           response = await executeRedshiftQuery(
@@ -1032,6 +1061,9 @@ export default class ConnectorsService {
         break;
       case 'duckdb':
         // DuckDB specific validations
+        if (!conn.database_path) throw new Error('Database path is required');
+        break;
+      case 'sqlite':
         if (!conn.database_path) throw new Error('Database path is required');
         break;
       case 'ducklake':
@@ -2038,6 +2070,9 @@ export default class ConnectorsService {
         });
         const schema = await extractor.extractSchema();
         return schema;
+      }
+      case 'sqlite': {
+        return { tables: extractSQLiteSchema(connection) };
       }
       case 'ducklake': {
         return { tables: [] };

--- a/src/main/utils/connectors.ts
+++ b/src/main/utils/connectors.ts
@@ -3,6 +3,7 @@ import pg from 'pg';
 import snowflake from 'snowflake-sdk';
 import { BigQuery } from '@google-cloud/bigquery';
 import { DuckDBInstance } from '@duckdb/node-api';
+import SqliteDatabase from 'better-sqlite3';
 import { DBSQLClient } from '@databricks/sql';
 import fs from 'fs';
 import {
@@ -15,6 +16,8 @@ import {
   QueryResponseType,
   RedshiftConnection,
   SnowflakeConnection,
+  SQLiteConnection,
+  Table,
 } from '../../types/backend';
 import { SNOWFLAKE_TYPE_MAP } from './constants';
 import SecureStorageService from '../services/secureStorage.service';
@@ -629,6 +632,171 @@ export async function testDuckDBConnection(
     } catch {
       /* empty */
     }
+  }
+}
+
+export function testSQLiteConnection(config: SQLiteConnection): boolean {
+  if (!config.database_path) {
+    throw new Error('SQLite database path is required.');
+  }
+
+  let database: SqliteDatabase.Database | null = null;
+  try {
+    const stats = fs.statSync(config.database_path);
+    if (stats.isDirectory()) {
+      throw new Error(
+        'The selected path is a directory. Please select a SQLite database file.',
+      );
+    }
+
+    database = new SqliteDatabase(config.database_path, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    const result = database
+      .prepare('SELECT sqlite_version() AS version')
+      .get() as { version?: string } | undefined;
+    return Boolean(result?.version);
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      throw new Error('The selected SQLite database file does not exist.');
+    }
+    if (error?.code === 'SQLITE_NOTADB' || error?.code === 'SQLITE_CORRUPT') {
+      throw new Error(
+        'The selected file is not a valid SQLite database or is corrupted.',
+      );
+    }
+    if (error?.code === 'SQLITE_CANTOPEN') {
+      throw new Error(
+        'The SQLite database could not be opened. Check the file path and permissions.',
+      );
+    }
+    throw error;
+  } finally {
+    database?.close();
+  }
+}
+
+function normalizeSQLiteValue(value: unknown): unknown {
+  if (typeof value === 'bigint') {
+    return Number.isSafeInteger(Number(value))
+      ? Number(value)
+      : value.toString();
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString('base64');
+  }
+  return value;
+}
+
+export function executeSQLiteQuery(
+  config: SQLiteConnection,
+  query: string,
+): QueryResponseType {
+  let database: SqliteDatabase.Database | null = null;
+  try {
+    database = new SqliteDatabase(config.database_path, {
+      fileMustExist: true,
+    });
+    const statement = database.prepare(query);
+
+    if (statement.reader) {
+      const columns = statement.columns();
+      const data = (statement.all() as Record<string, unknown>[]).map((row) =>
+        Object.fromEntries(
+          Object.entries(row).map(([key, value]) => [
+            key,
+            normalizeSQLiteValue(value),
+          ]),
+        ),
+      );
+      return {
+        success: true,
+        data: data as any[],
+        fields: columns.map((column) => ({ name: column.name, type: -1 })),
+        rowCount: data.length,
+      };
+    }
+
+    const result = statement.run();
+    const statementType = query.trimStart().split(/\s+/, 1)[0]?.toUpperCase();
+    const commandType = ['INSERT', 'UPDATE', 'DELETE', 'REPLACE'].includes(
+      statementType,
+    )
+      ? 'DML'
+      : 'DDL';
+    return {
+      success: true,
+      data: [],
+      fields: [],
+      rowCount: result.changes,
+      isCommand: true,
+      commandType,
+    };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error?.message || 'Unknown error occurred during query execution',
+    };
+  } finally {
+    database?.close();
+  }
+}
+
+function quoteSQLiteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+export function extractSQLiteSchema(config: SQLiteConnection): Table[] {
+  let database: SqliteDatabase.Database | null = null;
+  try {
+    database = new SqliteDatabase(config.database_path, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    const objects = database
+      .prepare(
+        `SELECT name, type
+         FROM sqlite_schema
+         WHERE type IN ('table', 'view')
+           AND name NOT LIKE 'sqlite_%'
+         ORDER BY name`,
+      )
+      .all() as { name: string; type: 'table' | 'view' }[];
+
+    return objects.map((object) => {
+      const columns = database!
+        .prepare(`PRAGMA table_xinfo(${quoteSQLiteIdentifier(object.name)})`)
+        .all() as {
+        cid: number;
+        name: string;
+        type: string;
+        notnull: number;
+        pk: number;
+      }[];
+
+      return {
+        name: object.name,
+        type: object.type.toUpperCase(),
+        schema: 'main',
+        columns: columns.map((column) => ({
+          name: column.name,
+          typeName: column.type || 'UNKNOWN',
+          ordinalPosition: column.cid + 1,
+          primaryKeySequenceId: column.pk,
+          columnDisplaySize: 0,
+          scale: 0,
+          precision: 0,
+          columnProperties: [],
+          autoincrement: false,
+          primaryKey: column.pk > 0,
+          nullable: column.notnull === 0,
+          foreignKeys: [],
+        })),
+      };
+    });
+  } finally {
+    database?.close();
   }
 }
 

--- a/src/renderer/components/connectionCards/style.tsx
+++ b/src/renderer/components/connectionCards/style.tsx
@@ -30,8 +30,8 @@ export const JdbcImage = styled('img')({
 
 export const ContentWrapper = styled(Box)({
   padding: 3,
-  height: 180,
-  width: 240,
+  height: 150,
+  width: 210,
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -48,8 +48,8 @@ export const StyledCardContent = styled(CardContent)({
 
 export const StyledCard = styled(Card)({
   maxWidth: 345,
-  width: 240,
-  height: 252,
+  width: 210,
+  height: 220,
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
@@ -63,7 +63,7 @@ export const StyledCard = styled(Card)({
 });
 
 export const MediaImage = styled('img')({
-  width: 140,
+  width: 115,
 });
 
 export const FileMediaImage = styled('img')({

--- a/src/renderer/components/connections/connection-header.tsx
+++ b/src/renderer/components/connections/connection-header.tsx
@@ -38,6 +38,8 @@ const ConnectionHeader = ({
           alignItems: 'center',
           width: '100%',
           mb: 2,
+          gap: 2,
+          flexWrap: 'wrap',
         }}
       >
         <Typography variant="h6" component="h5">

--- a/src/renderer/components/connections/index.ts
+++ b/src/renderer/components/connections/index.ts
@@ -4,6 +4,7 @@ import { BigQuery } from './bigquery';
 import { Redshift } from './redshift';
 import { Databricks } from './databricks';
 import { DuckDB } from './duckdb';
+import { SQLite } from './sqlite';
 import { Kinetica } from './kinetica';
 
 export const Connections = {
@@ -13,5 +14,6 @@ export const Connections = {
   Redshift,
   Databricks,
   DuckDB,
+  SQLite,
   Kinetica,
 };

--- a/src/renderer/components/connections/sqlite.tsx
+++ b/src/renderer/components/connections/sqlite.tsx
@@ -1,0 +1,239 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  TextField,
+} from '@mui/material';
+import { FolderOpen } from '@mui/icons-material';
+import { ConnectionModel, SQLiteConnection } from '../../../types/backend';
+import connectionIcons from '../../../../assets/connectionIcons';
+import {
+  useConfigureConnection,
+  useFilePicker,
+  useGetConnections,
+  useTestConnection,
+  useUpdateConnection,
+} from '../../controllers';
+import { useConnectionNameValidation } from '../../utils/connectionValidation';
+import ConnectionHeader from './connection-header';
+
+type Props = {
+  onCancel: () => void;
+  connection?: ConnectionModel;
+  duplicateFrom?: ConnectionModel;
+  suggestedName?: string;
+};
+
+function shortSQLitePath(databasePath: string): string {
+  return databasePath.split(/[\\/]/).pop() || '';
+}
+
+export const SQLite: React.FC<Props> = ({
+  onCancel,
+  connection,
+  duplicateFrom,
+  suggestedName,
+}) => {
+  const navigate = useNavigate();
+  const { mutate: getFiles } = useFilePicker();
+  const existingConnection = connection?.connection as
+    | SQLiteConnection
+    | undefined;
+  const duplicateConnection = duplicateFrom?.connection as
+    | SQLiteConnection
+    | undefined;
+  const [nameTouched, setNameTouched] = React.useState(false);
+  const [connectionTested, setConnectionTested] = React.useState(false);
+  const [formState, setFormState] = React.useState<SQLiteConnection>({
+    type: 'sqlite',
+    name: existingConnection?.name ?? suggestedName ?? 'SQLite Connection',
+    database_path:
+      existingConnection?.database_path ??
+      duplicateConnection?.database_path ??
+      '',
+    short_database_path: shortSQLitePath(
+      existingConnection?.database_path ??
+        duplicateConnection?.database_path ??
+        '',
+    ),
+    database:
+      existingConnection?.database_path ??
+      duplicateConnection?.database_path ??
+      '',
+    schema: 'main',
+  });
+  const { data: existingConnections = [] } = useGetConnections();
+  const { validateName } = useConnectionNameValidation(
+    existingConnections,
+    connection?.id,
+  );
+  const nameValidation = validateName(formState.name);
+  const { mutate: configureConnection, isLoading: isConfiguring } =
+    useConfigureConnection({
+      onSuccess: () => {
+        toast.success('SQLite connection created successfully!');
+        navigate('/app/connections');
+      },
+      onError: (error) => {
+        toast.error(`Configuration failed: ${error}`);
+      },
+    });
+  const { mutate: updateConnection, isLoading: isUpdating } =
+    useUpdateConnection({
+      onSuccess: () => {
+        toast.success('SQLite connection updated successfully!');
+        navigate('/app/connections');
+      },
+      onError: (error) => {
+        toast.error(`Update failed: ${error}`);
+      },
+    });
+  const { mutate: testConnection, isLoading: isTesting } = useTestConnection({
+    onSuccess: (success) => {
+      setConnectionTested(success === true);
+      if (success) toast.success('SQLite connection test successful!');
+      else toast.error('SQLite connection test failed');
+    },
+    onError: (error) => {
+      setConnectionTested(false);
+      toast.error(`Test failed: ${error.message}`);
+    },
+  });
+
+  useEffect(() => {
+    setFormState((previous) => ({
+      ...previous,
+      database: previous.database_path,
+      short_database_path: shortSQLitePath(previous.database_path),
+    }));
+  }, [formState.database_path]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!nameValidation.isValid) {
+      toast.error(nameValidation.message || 'Invalid connection name');
+      return;
+    }
+    const connectionData = { ...formState, database: formState.database_path };
+    if (connection) {
+      updateConnection({
+        connection: { id: connection.id, connection: connectionData },
+      });
+    } else {
+      configureConnection({ connection: connectionData });
+    }
+  };
+
+  const handleFileSelect = () => {
+    getFiles(
+      {
+        properties: ['openFile'],
+        filters: [
+          { name: 'SQLite databases', extensions: ['db', 'sqlite', 'sqlite3'] },
+        ],
+      },
+      {
+        onSuccess: (filePaths) => {
+          if (filePaths?.[0]) {
+            setConnectionTested(false);
+            setFormState((previous) => ({
+              ...previous,
+              database_path: filePaths[0],
+            }));
+          }
+        },
+        onError: () => {
+          toast.error('Failed to select SQLite database file');
+        },
+      },
+    );
+  };
+
+  const handleTest = () => {
+    setConnectionTested(false);
+    testConnection({ ...formState, database: formState.database_path });
+  };
+  const testButtonLabel = connectionTested ? 'Connected' : 'Test Connection';
+
+  return (
+    <Box sx={{ width: '100%', p: 3 }}>
+      <ConnectionHeader
+        title="SQLite Connection"
+        imageSource={connectionIcons.images.sqlite}
+        onClose={onCancel}
+        onSave={handleSubmit}
+        isLoading={isUpdating || isConfiguring}
+      />
+      <Box
+        component="form"
+        onSubmit={handleSubmit}
+        sx={{
+          maxWidth: 500,
+          mx: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+        }}
+      >
+        <TextField
+          label="Connection Name"
+          name="name"
+          value={formState.name}
+          onChange={(event) =>
+            setFormState((previous) => ({
+              ...previous,
+              name: event.target.value,
+            }))
+          }
+          onBlur={() => setNameTouched(true)}
+          required
+          error={nameTouched && !nameValidation.isValid}
+          helperText={
+            nameTouched && !nameValidation.isValid ? nameValidation.message : ''
+          }
+        />
+        <TextField
+          label="SQLite Database File"
+          value={formState.database_path}
+          onChange={(event) => {
+            setConnectionTested(false);
+            setFormState((previous) => ({
+              ...previous,
+              database_path: event.target.value,
+            }));
+          }}
+          required
+          placeholder="/path/to/database.sqlite"
+          helperText="Select an existing .db, .sqlite, or .sqlite3 file."
+          slotProps={{
+            input: {
+              endAdornment: (
+                <IconButton
+                  onClick={handleFileSelect}
+                  edge="end"
+                  aria-label="Select SQLite database file"
+                >
+                  <FolderOpen />
+                </IconButton>
+              ),
+            },
+          }}
+        />
+        <Button
+          type="button"
+          variant="contained"
+          onClick={handleTest}
+          disabled={isTesting || !formState.database_path}
+          startIcon={isTesting ? <CircularProgress size={18} /> : undefined}
+          sx={{ alignSelf: 'flex-start' }}
+        >
+          {isTesting ? 'Testing...' : testButtonLabel}
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/src/renderer/components/connections/sqlite.tsx
+++ b/src/renderer/components/connections/sqlite.tsx
@@ -50,7 +50,7 @@ export const SQLite: React.FC<Props> = ({
   const [connectionTested, setConnectionTested] = React.useState(false);
   const [formState, setFormState] = React.useState<SQLiteConnection>({
     type: 'sqlite',
-    name: existingConnection?.name ?? suggestedName ?? 'SQLite Connection',
+    name: existingConnection?.name ?? suggestedName ?? '',
     database_path:
       existingConnection?.database_path ??
       duplicateConnection?.database_path ??

--- a/src/renderer/components/modals/addConnectionModal/index.tsx
+++ b/src/renderer/components/modals/addConnectionModal/index.tsx
@@ -13,7 +13,11 @@ import {
   Typography,
 } from '@mui/material';
 import { toast } from 'react-toastify';
-import { Project, ConnectionModel } from '../../../../types/backend';
+import {
+  Project,
+  ConnectionModel,
+  canUseAsDbtConnection,
+} from '../../../../types/backend';
 
 interface AddConnectionModalProps {
   isOpen: boolean;
@@ -78,21 +82,25 @@ export const AddConnectionModal: React.FC<AddConnectionModalProps> = ({
             label="Connection"
             onChange={(e) => setSelectedConnectionId(e.target.value)}
           >
-            {connections.map((connection) => (
-              <MenuItem key={connection.id} value={connection.id}>
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <Typography variant="body2">
-                    {connection.connection.name}
-                  </Typography>
-                  <Typography
-                    variant="caption"
-                    sx={{ ml: 1, color: 'text.secondary' }}
-                  >
-                    ({connection.connection.type})
-                  </Typography>
-                </Box>
-              </MenuItem>
-            ))}
+            {connections
+              .filter((connection) =>
+                canUseAsDbtConnection(connection.connection.type),
+              )
+              .map((connection) => (
+                <MenuItem key={connection.id} value={connection.id}>
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <Typography variant="body2">
+                      {connection.connection.name}
+                    </Typography>
+                    <Typography
+                      variant="caption"
+                      sx={{ ml: 1, color: 'text.secondary' }}
+                    >
+                      ({connection.connection.type})
+                    </Typography>
+                  </Box>
+                </MenuItem>
+              ))}
           </Select>
         </FormControl>
       </DialogContent>

--- a/src/renderer/components/newProject/index.tsx
+++ b/src/renderer/components/newProject/index.tsx
@@ -293,17 +293,21 @@ export const NewProject: React.FC<NewProjectProps> = ({
                     <Typography>New Connection</Typography>
                   </Box>
                 </MenuItem>
-                {connections.map((connection) => (
-                  <MenuItem key={connection.id} value={connection.id}>
-                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                      <ConnectionIconContainer>
-                        {renderConnectionIcon(connection.connection.type)}
-                      </ConnectionIconContainer>
-                      {connection.connection.name} -{' '}
-                      {connection.connection.type}
-                    </Box>
-                  </MenuItem>
-                ))}
+                {connections
+                  .filter(
+                    (connection) => connection.connection.type !== 'sqlite',
+                  )
+                  .map((connection) => (
+                    <MenuItem key={connection.id} value={connection.id}>
+                      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                        <ConnectionIconContainer>
+                          {renderConnectionIcon(connection.connection.type)}
+                        </ConnectionIconContainer>
+                        {connection.connection.name} -{' '}
+                        {connection.connection.type}
+                      </Box>
+                    </MenuItem>
+                  ))}
               </Select>
             </FormControl>
           ) : (

--- a/src/renderer/helpers/utils.ts
+++ b/src/renderer/helpers/utils.ts
@@ -10,6 +10,7 @@ import {
   PostgresConnection,
   Project,
   RedshiftConnection,
+  SQLiteConnection,
   SnowflakeConnection,
   Table,
 } from '../../types/backend';
@@ -261,6 +262,15 @@ export const getConnectionInput = (conn: ConnectionModel) => {
         database_path: duck.database_path,
         database: duck.database,
         schema: duck.schema || 'main',
+        name: connection.name,
+      };
+    case 'sqlite':
+      const sqlite = connection as SQLiteConnection;
+      return {
+        type,
+        database_path: sqlite.database_path,
+        database: sqlite.database_path,
+        schema: 'main',
         name: connection.name,
       };
     case 'kinetica':

--- a/src/renderer/screens/addConnection/index.tsx
+++ b/src/renderer/screens/addConnection/index.tsx
@@ -78,6 +78,12 @@ const baseItems: ItemType[] = [
     disabled: false,
   },
   {
+    id: 'sqlite',
+    name: 'SQLite',
+    img: 'sqlite',
+    disabled: false,
+  },
+  {
     id: 'kinetica',
     name: 'Kinetica',
     img: 'kinetica',
@@ -169,6 +175,15 @@ const AddConnection: React.FC = () => {
           />
         );
       }
+      case 'sqlite': {
+        return (
+          <Connections.SQLite
+            onCancel={() => setSelectedItem(undefined)}
+            duplicateFrom={duplicateData}
+            suggestedName={suggestedName}
+          />
+        );
+      }
       case 'kinetica': {
         return (
           <Connections.Kinetica
@@ -219,13 +234,15 @@ const AddConnection: React.FC = () => {
             </Typography>
 
             <ConnectionCardsContainer>
-              {baseItems.map((item, index) => (
-                <ConnectionCard
-                  itemDetails={item}
-                  onClick={() => setSelectedItem(item)}
-                  key={index}
-                />
-              ))}
+              {baseItems
+                .filter((item) => !projectId || item.id !== 'sqlite')
+                .map((item, index) => (
+                  <ConnectionCard
+                    itemDetails={item}
+                    onClick={() => setSelectedItem(item)}
+                    key={index}
+                  />
+                ))}
             </ConnectionCardsContainer>
           </Box>
         </ConnectionContainer>

--- a/src/renderer/screens/connections/index.tsx
+++ b/src/renderer/screens/connections/index.tsx
@@ -309,6 +309,7 @@ const Connections: React.FC = () => {
           </Typography>
         );
       case 'duckdb':
+      case 'sqlite':
         return (
           <Typography variant="body2" color="text.secondary">
             Path: {connection.short_database_path || connection.database_path}

--- a/src/renderer/screens/editConnection/index.tsx
+++ b/src/renderer/screens/editConnection/index.tsx
@@ -80,6 +80,15 @@ const EditConnection: React.FC = () => {
           />
         );
       }
+      case 'sqlite': {
+        return (
+          <Connections.SQLite
+            key={connId}
+            onCancel={handleCancel}
+            connection={conn}
+          />
+        );
+      }
       case 'kinetica': {
         return (
           <Connections.Kinetica

--- a/src/renderer/screens/selectProject/index.tsx
+++ b/src/renderer/screens/selectProject/index.tsx
@@ -598,7 +598,9 @@ const SelectProject: React.FC = () => {
             connectionType={connectionType}
             setConnectionType={setConnectionType}
             isLoadingConnections={isLoadingConnections}
-            connections={connections}
+            connections={connections.filter(
+              (connection) => connection.connection.type !== 'sqlite',
+            )}
             datalakeInstances={datalakeInstances}
             isLoadingDatalakes={isLoadingDatalakes}
             navigate={navigate}

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -14,6 +14,7 @@ export type SupportedConnectionTypes =
   | 'kinetica'
   | 'googlecloud'
   | 'duckdb'
+  | 'sqlite'
   | 'ducklake';
 
 export type ConnectionBase = {
@@ -87,6 +88,12 @@ export type DuckDBConnection = Omit<ConnectionBase, 'username' | 'password'> & {
   // No username/password needed for DuckDB
 };
 
+export type SQLiteConnection = Omit<ConnectionBase, 'username' | 'password'> & {
+  type: 'sqlite';
+  database_path: string;
+  short_database_path: string;
+};
+
 export type KineticaConnection = ConnectionBase & {
   type: 'kinetica';
   host: string;
@@ -115,8 +122,13 @@ export type ConnectionInput =
   | RedshiftConnection
   | DatabricksConnection
   | DuckDBConnection
+  | SQLiteConnection
   | KineticaConnection
   | DuckLakeConnectionConfig;
+
+export const canUseAsDbtConnection = (
+  type: SupportedConnectionTypes,
+): boolean => type !== 'sqlite';
 
 export type ConnectionModel = {
   id: string;

--- a/tests/unit/main/services/connectors.service.test.ts
+++ b/tests/unit/main/services/connectors.service.test.ts
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import ConnectorsService from '../../../../src/main/services/connectors.service';
+import { ProjectsService } from '../../../../src/main/services';
 
 const testPostgresConnection = jest.fn();
+const testSQLiteConnection = jest.fn();
+const executeSQLiteQuery = jest.fn();
 const getCredential = jest.fn();
 
 jest.mock('openai', () => ({
@@ -38,12 +41,15 @@ jest.mock('../../../../src/main/utils/connectors', () => ({
   executePostgresQuery: jest.fn(),
   executeRedshiftQuery: jest.fn(),
   executeSnowflakeQuery: jest.fn(),
+  executeSQLiteQuery: (...args: any[]) => executeSQLiteQuery(...args),
+  extractSQLiteSchema: jest.fn(),
   testBigQueryConnection: jest.fn(),
   testDatabricksConnection: jest.fn(),
   testDuckDBConnection: jest.fn(),
   testPostgresConnection: (...args: any[]) => testPostgresConnection(...args),
   testRedshiftConnection: jest.fn(),
   testSnowflakeConnection: jest.fn(),
+  testSQLiteConnection: (...args: any[]) => testSQLiteConnection(...args),
 }));
 
 describe('ConnectorsService (main)', () => {
@@ -57,6 +63,50 @@ describe('ConnectorsService (main)', () => {
       await expect(
         ConnectorsService.validateConnection({} as any),
       ).rejects.toThrow('Connection type is required');
+    });
+
+    it('accepts a standalone SQLite file connection shape', async () => {
+      await expect(
+        ConnectorsService.validateConnection({
+          type: 'sqlite',
+          name: 'Local analytics',
+          database_path: '/tmp/analytics.sqlite',
+          short_database_path: 'analytics.sqlite',
+          database: '/tmp/analytics.sqlite',
+          schema: 'main',
+        } as any),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rejects SQLite without a database path', async () => {
+      await expect(
+        ConnectorsService.validateConnection({
+          type: 'sqlite',
+          name: 'Local analytics',
+        } as any),
+      ).rejects.toThrow('Database path is required');
+    });
+  });
+
+  describe('SQLite dbt project boundary', () => {
+    it('rejects configuring SQLite for an existing dbt project', async () => {
+      (ProjectsService.loadProjects as jest.Mock).mockResolvedValueOnce([
+        { id: 'project-1', name: 'Project', path: '/tmp/project' },
+      ]);
+
+      await expect(
+        ConnectorsService.configureConnection({
+          projectId: 'project-1',
+          connection: {
+            type: 'sqlite',
+            name: 'Local analytics',
+            database_path: '/tmp/analytics.sqlite',
+            short_database_path: 'analytics.sqlite',
+            database: '/tmp/analytics.sqlite',
+            schema: 'main',
+          } as any,
+        }),
+      ).rejects.toThrow('SQLite connections cannot be used by dbt projects');
     });
   });
 
@@ -80,11 +130,57 @@ describe('ConnectorsService (main)', () => {
       expect(testPostgresConnection).toHaveBeenCalledWith(connection);
     });
 
+    it('calls testSQLiteConnection for SQLite connections', async () => {
+      testSQLiteConnection.mockReturnValue(true);
+      const connection = {
+        type: 'sqlite',
+        name: 'Local analytics',
+        database_path: '/tmp/analytics.sqlite',
+        short_database_path: 'analytics.sqlite',
+        database: '/tmp/analytics.sqlite',
+        schema: 'main',
+      } as any;
+
+      await expect(ConnectorsService.testConnection(connection)).resolves.toBe(
+        true,
+      );
+      expect(testSQLiteConnection).toHaveBeenCalledWith(connection);
+    });
+
     it('validates before testing (missing type fails)', async () => {
       await expect(ConnectorsService.testConnection({} as any)).rejects.toThrow(
         'Connection type is required',
       );
       expect(testPostgresConnection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SQLite query execution', () => {
+    it('routes SQLite through the existing execute statement flow', async () => {
+      const connection = {
+        type: 'sqlite',
+        name: 'Local analytics',
+        database_path: '/tmp/analytics.sqlite',
+        database: '/tmp/analytics.sqlite',
+        schema: 'main',
+      } as any;
+      executeSQLiteQuery.mockReturnValue({
+        success: true,
+        data: [{ value: 42 }],
+        fields: [{ name: 'value', type: -1 }],
+      });
+
+      await expect(
+        ConnectorsService.executeSelectStatement({
+          connection,
+          query: 'SELECT value FROM metrics',
+          projectName: connection.name,
+        }),
+      ).resolves.toMatchObject({ success: true, data: [{ value: 42 }] });
+      expect(executeSQLiteQuery).toHaveBeenCalledWith(
+        connection,
+        'SELECT value FROM metrics',
+      );
     });
   });
 

--- a/tests/unit/main/utils/sqliteConnector.test.ts
+++ b/tests/unit/main/utils/sqliteConnector.test.ts
@@ -1,0 +1,199 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  executeSQLiteQuery,
+  extractSQLiteSchema,
+  testSQLiteConnection,
+} from '../../../../src/main/utils/connectors';
+import type { SQLiteConnection } from '../../../../src/types/backend';
+
+jest.mock('better-sqlite3', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('../../../../release/app/node_modules/better-sqlite3', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const MockSqliteDatabase = jest.requireMock(
+  '../../../../release/app/node_modules/better-sqlite3',
+).default as jest.Mock;
+const close = jest.fn();
+const get = jest.fn();
+const prepare: jest.Mock = jest.fn(() => ({ get }));
+
+describe('testSQLiteConnection', () => {
+  let directory: string;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-connector-'));
+    close.mockClear();
+    get.mockReset().mockReturnValue({ version: '3.46.0' });
+    prepare.mockClear();
+    MockSqliteDatabase.mockReset().mockImplementation(() => ({
+      close,
+      prepare,
+    }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  const connection = (databasePath: string): SQLiteConnection => ({
+    type: 'sqlite',
+    name: 'Local analytics',
+    database_path: databasePath,
+    short_database_path: path.basename(databasePath),
+    database: databasePath,
+    schema: 'main',
+  });
+
+  it('opens an existing SQLite database without modifying its data', () => {
+    const databasePath = path.join(directory, 'analytics.sqlite');
+    fs.writeFileSync(databasePath, 'existing database bytes');
+    const before = fs.readFileSync(databasePath);
+
+    expect(testSQLiteConnection(connection(databasePath))).toBe(true);
+
+    expect(MockSqliteDatabase).toHaveBeenCalledWith(databasePath, {
+      readonly: true,
+      fileMustExist: true,
+    });
+    expect(prepare).toHaveBeenCalledWith('SELECT sqlite_version() AS version');
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(databasePath)).toEqual(before);
+  });
+
+  it('rejects missing files, directories, and non-SQLite files', () => {
+    expect(() =>
+      testSQLiteConnection(connection(path.join(directory, 'missing.sqlite'))),
+    ).toThrow('does not exist');
+    expect(() => testSQLiteConnection(connection(directory))).toThrow(
+      'selected path is a directory',
+    );
+
+    const textFile = path.join(directory, 'not-sqlite.db');
+    fs.writeFileSync(textFile, 'plain text');
+    MockSqliteDatabase.mockImplementationOnce(() => {
+      const error = new Error('file is not a database') as Error & {
+        code: string;
+      };
+      error.code = 'SQLITE_NOTADB';
+      throw error;
+    });
+    expect(() => testSQLiteConnection(connection(textFile))).toThrow(
+      'not a valid SQLite database',
+    );
+  });
+
+  it('returns rows and normalizes values for the existing result grid', () => {
+    prepare.mockReturnValueOnce({
+      reader: true,
+      columns: () => [
+        { name: 'safe_id' },
+        { name: 'large_id' },
+        { name: 'data' },
+      ],
+      all: () => [
+        {
+          safe_id: BigInt(42),
+          large_id: BigInt('9007199254740993'),
+          data: Buffer.from('sqlite'),
+        },
+      ],
+    });
+
+    expect(
+      executeSQLiteQuery(connection('/tmp/analytics.sqlite'), 'SELECT 1'),
+    ).toEqual({
+      success: true,
+      data: [
+        {
+          safe_id: 42,
+          large_id: '9007199254740993',
+          data: Buffer.from('sqlite').toString('base64'),
+        },
+      ],
+      fields: [
+        { name: 'safe_id', type: -1 },
+        { name: 'large_id', type: -1 },
+        { name: 'data', type: -1 },
+      ],
+      rowCount: 1,
+    });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns affected rows for non-row statements', () => {
+    prepare.mockReturnValueOnce({
+      reader: false,
+      run: () => ({ changes: 2 }),
+    });
+
+    expect(
+      executeSQLiteQuery(
+        connection('/tmp/analytics.sqlite'),
+        'UPDATE metrics SET value = 1',
+      ),
+    ).toEqual({
+      success: true,
+      data: [],
+      fields: [],
+      rowCount: 2,
+      isCommand: true,
+      commandType: 'DML',
+    });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('extracts tables and views and safely quotes object names', () => {
+    prepare.mockImplementation((sql: string) => {
+      if (sql.includes('FROM sqlite_schema')) {
+        return {
+          all: () => [
+            { name: 'metrics', type: 'table' },
+            { name: 'odd"view', type: 'view' },
+          ],
+        };
+      }
+      if (sql === 'PRAGMA table_xinfo("metrics")') {
+        return {
+          all: () => [
+            { cid: 0, name: 'id', type: 'INTEGER', notnull: 1, pk: 1 },
+          ],
+        };
+      }
+      if (sql === 'PRAGMA table_xinfo("odd""view")') {
+        return {
+          all: () => [
+            { cid: 0, name: 'label', type: 'TEXT', notnull: 0, pk: 0 },
+          ],
+        };
+      }
+      throw new Error(`Unexpected schema query: ${sql}`);
+    });
+
+    const tables = extractSQLiteSchema(connection('/tmp/analytics.sqlite'));
+
+    expect(tables).toHaveLength(2);
+    expect(tables[0]).toMatchObject({
+      name: 'metrics',
+      type: 'TABLE',
+      schema: 'main',
+      columns: [
+        {
+          name: 'id',
+          typeName: 'INTEGER',
+          ordinalPosition: 1,
+          primaryKey: true,
+          nullable: false,
+        },
+      ],
+    });
+    expect(tables[1]).toMatchObject({ name: 'odd"view', type: 'VIEW' });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/renderer/helpers/utils.test.ts
+++ b/tests/unit/renderer/helpers/utils.test.ts
@@ -13,6 +13,7 @@ import {
   getNonEditableFileMessage,
   compileCommand,
   generateFilename,
+  getConnectionInput,
 } from '../../../../src/renderer/helpers/utils';
 
 jest.mock('../../../../src/renderer/services', () => {
@@ -67,9 +68,9 @@ describe('renderer/helpers/utils', () => {
 
   describe('splitPath', () => {
     it('should strip project name prefix', () => {
-      expect(
-        splitPath('/Users/me/project/models/my.sql', 'project'),
-      ).toBe('/models/my.sql');
+      expect(splitPath('/Users/me/project/models/my.sql', 'project')).toBe(
+        '/models/my.sql',
+      );
     });
 
     it('should return original path if project name is not present', () => {
@@ -113,9 +114,9 @@ describe('renderer/helpers/utils', () => {
 
   describe('extractModelNameFromPath', () => {
     it('should convert models folder path to dot notation without extension', () => {
-      expect(
-        extractModelNameFromPath('/p/models/staging/my_model.sql'),
-      ).toBe('staging.my_model');
+      expect(extractModelNameFromPath('/p/models/staging/my_model.sql')).toBe(
+        'staging.my_model',
+      );
     });
 
     it('should return empty string when models folder missing', () => {
@@ -185,6 +186,30 @@ describe('renderer/helpers/utils', () => {
       expect(name).toMatch(/^prefix_\d{8}_\d{6}\.csv$/);
 
       jest.useRealTimers();
+    });
+  });
+
+  describe('getConnectionInput', () => {
+    it('maps SQLite connections for SQL Editor and Notebook loading', () => {
+      expect(
+        getConnectionInput({
+          id: 'sqlite-connection',
+          connection: {
+            type: 'sqlite',
+            name: 'SQLite Connection',
+            database_path: '/tmp/analytics.sqlite',
+            short_database_path: 'analytics.sqlite',
+            database: '/tmp/analytics.sqlite',
+            schema: 'main',
+          },
+        } as any),
+      ).toEqual({
+        type: 'sqlite',
+        name: 'SQLite Connection',
+        database_path: '/tmp/analytics.sqlite',
+        database: '/tmp/analytics.sqlite',
+        schema: 'main',
+      });
     });
   });
 });

--- a/tests/unit/renderer/utils/analyticsQueryEngine.test.ts
+++ b/tests/unit/renderer/utils/analyticsQueryEngine.test.ts
@@ -1,0 +1,73 @@
+import { executeQueryForConnection } from '../../../../src/renderer/services/connectors.service';
+import { DuckLakeService } from '../../../../src/renderer/services/duckLake.service';
+import { executeAnalyticsQuery } from '../../../../src/renderer/utils/analyticsQueryEngine';
+
+jest.mock('../../../../src/renderer/services/connectors.service', () => ({
+  executeQueryForConnection: jest.fn(),
+}));
+
+jest.mock('../../../../src/renderer/services/duckLake.service', () => ({
+  DuckLakeService: {
+    executeQuery: jest.fn(),
+  },
+}));
+
+const executeConnectorQuery = executeQueryForConnection as jest.Mock;
+const executeDuckLakeQuery = DuckLakeService.executeQuery as jest.Mock;
+
+describe('executeAnalyticsQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('routes SQLite through the regular connector path with the preview cap', async () => {
+    executeConnectorQuery.mockResolvedValue({
+      success: true,
+      data: [{ customer_count: 3 }],
+      fields: [{ name: 'customer_count', type: -1 }],
+      duration: 4,
+    });
+
+    await expect(
+      executeAnalyticsQuery({
+        queryName: 'customer_summary',
+        sql: 'SELECT COUNT(*) AS customer_count FROM customers',
+        connectionId: 'sqlite-connection',
+      }),
+    ).resolves.toEqual({
+      name: 'customer_summary',
+      status: 'success',
+      data: [{ customer_count: 3 }],
+      fields: ['customer_count'],
+      rowCount: 1,
+      duration: 4,
+    });
+
+    expect(executeConnectorQuery).toHaveBeenCalledWith({
+      connectionId: 'sqlite-connection',
+      query:
+        'SELECT * FROM (\nSELECT COUNT(*) AS customer_count FROM customers\n) AS _limit_wrapper LIMIT 500',
+    });
+    expect(executeDuckLakeQuery).not.toHaveBeenCalled();
+  });
+
+  it('returns regular connector errors without invoking DuckLake', async () => {
+    executeConnectorQuery.mockResolvedValue({
+      success: false,
+      error: 'no such table: missing_table',
+    });
+
+    await expect(
+      executeAnalyticsQuery({
+        queryName: 'missing',
+        sql: 'SELECT * FROM missing_table',
+        connectionId: 'sqlite-connection',
+      }),
+    ).resolves.toMatchObject({
+      name: 'missing',
+      status: 'error',
+      error: 'no such table: missing_table',
+    });
+    expect(executeDuckLakeQuery).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/shared/sqliteConnectionScope.test.ts
+++ b/tests/unit/shared/sqliteConnectionScope.test.ts
@@ -1,0 +1,10 @@
+import { canUseAsDbtConnection } from '../../../src/types/backend';
+
+describe('SQLite connection scope', () => {
+  it('keeps SQLite out of dbt projects without changing existing types', () => {
+    expect(canUseAsDbtConnection('sqlite')).toBe(false);
+    expect(canUseAsDbtConnection('postgres')).toBe(true);
+    expect(canUseAsDbtConnection('duckdb')).toBe(true);
+    expect(canUseAsDbtConnection('ducklake')).toBe(true);
+  });
+});


### PR DESCRIPTION
- add SQLite connection creation, editing, testing, and file selection
- support SQLite queries and schema browsing in SQL Editor and Notebooks
- reuse existing Analytics pages, queries, tables, charts, and AI tools
- keep SQLite excluded from all dbt project and profile flows
- add SQLite icons, error handling, value normalization, and focused tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQLite database support, including connection creation, editing, duplication, testing, and saving.
  * Added database file selection, query execution, schema browsing, and connection details.
  * Added SQLite icons and display support throughout connection screens.

* **Bug Fixes**
  * Excluded SQLite from dbt-specific and new project connection selections.
  * Improved validation and handling of missing or invalid database files.

* **Style**
  * Reduced connection card sizing and improved header spacing and wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->