### PR TITLE
fix sql-editor-pagination to reset page to 0 when rows-per-page changes to prevent empty results on last page

### DIFF
--- a/src/renderer/components/customTable/index.tsx
+++ b/src/renderer/components/customTable/index.tsx
@@ -152,6 +152,7 @@ const CustomTable = <T,>({
                 customPagination?.setPerPage(value);
                 return;
               }
+              setPage(0);
               setPerPage(String(value));
             }}
             total={customPagination?.count ?? rows.length}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changing the table’s page size now automatically returns to the first page when custom pagination is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->