### PR TITLE
fix(duckdb): extract schema over a single connection

### DIFF
--- a/src/main/extractor/duckdb.extractor.ts
+++ b/src/main/extractor/duckdb.extractor.ts
@@ -1,5 +1,4 @@
-/* eslint-disable no-restricted-syntax, no-await-in-loop, consistent-return */
-import { DuckDBInstance } from '@duckdb/node-api';
+import { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
 import { Column, Table } from '../../types/backend';
 
 export default class DuckDBSchemaExtractor {
@@ -12,237 +11,80 @@ export default class DuckDBSchemaExtractor {
     this.schema = config.schema || 'main';
   }
 
-  private async executeQuery(query: string): Promise<any[]> {
-    let instance: any = null;
-    let connection: any = null;
+  /**
+   * DuckDB holds an exclusive lock on the database file, so opening a second
+   * instance while the first is still alive fails. Everything is read over one
+   * connection, and tables and views come from a single query so that an object
+   * can never be collected twice under two different types.
+   */
+  async extractSchema(): Promise<{ tables: Table[] }> {
+    const instance = await DuckDBInstance.create(this.database_path);
+    let connection: DuckDBConnection | undefined;
 
     try {
-      instance = await DuckDBInstance.create(this.database_path);
       connection = await instance.connect();
 
-      // Set schema context if not 'main'
-      if (this.schema && this.schema !== 'main') {
-        try {
-          await connection.run(`USE ${this.schema}`);
-        } catch (schemaError: any) {
-          // If schema doesn't exist, throw a clear error
-          if (
-            schemaError.message?.includes('does not exist') ||
-            schemaError.message?.includes('not found')
-          ) {
-            throw new Error(
-              `Schema '${this.schema}' does not exist in the DuckDB database.`,
-            );
-          }
-        }
-      }
+      const columnsByTable = await this.getColumnsByTable(connection);
+      const objects = await this.query(
+        connection,
+        `SELECT table_name, table_type
+         FROM information_schema.tables
+         WHERE table_schema = ?
+         ORDER BY table_name`,
+      );
 
-      const result = await connection.run(query);
-      return await result.getRows();
+      return {
+        tables: objects.map((object) => ({
+          name: object.table_name,
+          type: object.table_type === 'VIEW' ? 'VIEW' : 'TABLE',
+          schema: this.schema,
+          columns: columnsByTable.get(object.table_name) ?? [],
+        })),
+      };
     } finally {
-      try {
-        if (connection) {
-          if (typeof connection.close === 'function') {
-            await connection.close();
-          } else if (typeof connection.closeSync === 'function') {
-            connection.closeSync();
-          }
-        }
-      } catch {
-        /* empty */
-      }
-
-      try {
-        if (instance) {
-          if (typeof instance.close === 'function') {
-            await instance.close();
-          } else if (typeof instance.closeSync === 'function') {
-            instance.closeSync();
-          } else if (typeof instance.terminate === 'function') {
-            await instance.terminate();
-          }
-        }
-      } catch {
-        /* empty */
-      }
+      connection?.closeSync();
+      instance.closeSync();
     }
   }
 
-  private async getTables(): Promise<string[]> {
-    try {
-      const rows = await this.executeQuery(`
-        SELECT table_name
-        FROM information_schema.tables
-        WHERE table_schema = '${this.schema}'
-          AND table_type = 'BASE TABLE'
-      `);
-      return rows
-        .map((row) => {
-          if (Array.isArray(row)) {
-            return row[0];
-          }
-          return row.table_name;
-        })
-        .filter((name) => name && typeof name === 'string');
-    } catch (error) {
-      try {
-        const rows = await this.executeQuery('SHOW TABLES');
-        return rows
-          .map((row) => {
-            if (Array.isArray(row)) {
-              return row[0];
-            }
-            return row.name;
-          })
-          .filter((name) => name && typeof name === 'string');
-      } catch (fallbackError) {
-        return [];
-      }
-    }
+  private async getColumnsByTable(
+    connection: DuckDBConnection,
+  ): Promise<Map<string, Column[]>> {
+    const rows = await this.query(
+      connection,
+      `SELECT table_name, column_name, data_type, ordinal_position, is_nullable
+       FROM information_schema.columns
+       WHERE table_schema = ?
+       ORDER BY table_name, ordinal_position`,
+    );
+
+    const columnsByTable = new Map<string, Column[]>();
+    rows.forEach((row) => {
+      const columns = columnsByTable.get(row.table_name) ?? [];
+      columns.push({
+        name: row.column_name,
+        typeName: row.data_type,
+        ordinalPosition: row.ordinal_position,
+        primaryKeySequenceId: 0,
+        columnDisplaySize: 0,
+        scale: 0,
+        precision: 0,
+        columnProperties: [],
+        autoincrement: false,
+        primaryKey: false,
+        nullable: row.is_nullable === 'YES',
+      });
+      columnsByTable.set(row.table_name, columns);
+    });
+
+    return columnsByTable;
   }
 
-  private async getViews(): Promise<string[]> {
-    try {
-      const rows = await this.executeQuery(`
-        SELECT table_name
-        FROM information_schema.tables
-        WHERE table_schema = '${this.schema}'
-          AND table_type = 'VIEW'
-      `);
-      return rows
-        .map((row) => {
-          if (Array.isArray(row)) {
-            return row[0];
-          }
-          return row.table_name;
-        })
-        .filter((name) => name && typeof name === 'string');
-    } catch (error) {
-      return [];
-    }
-  }
-
-  private async getDetailedColumns(tableName: string): Promise<Column[]> {
-    try {
-      const rows = await this.executeQuery(`
-        SELECT
-          column_name,
-          data_type,
-          ordinal_position,
-          is_nullable,
-          column_default
-        FROM information_schema.columns
-        WHERE table_name = '${tableName}'
-          AND table_schema = '${this.schema}'
-        ORDER BY ordinal_position
-      `);
-
-      return rows
-        .map((row, index) => {
-          let columnName;
-          let dataType;
-          let ordinalPosition;
-          let isNullable;
-
-          if (Array.isArray(row)) {
-            [columnName, dataType, ordinalPosition, isNullable] = row;
-          } else {
-            columnName = row.column_name;
-            dataType = row.data_type;
-            ordinalPosition = row.ordinal_position;
-            isNullable = row.is_nullable;
-          }
-
-          return {
-            name: columnName,
-            typeName: dataType,
-            ordinalPosition: ordinalPosition || index + 1,
-            primaryKeySequenceId: 0,
-            columnDisplaySize: 0,
-            scale: 0,
-            precision: 0,
-            columnProperties: [],
-            autoincrement: false,
-            primaryKey: false,
-            nullable: isNullable === 'YES',
-          };
-        })
-        .filter((col) => col.name && typeof col.name === 'string');
-    } catch (error) {
-      try {
-        const rows = await this.executeQuery(`DESCRIBE ${tableName}`);
-        return rows
-          .map((row, index) => {
-            let columnName;
-            let columnType;
-            let nullable;
-
-            if (Array.isArray(row)) {
-              [columnName, columnType, , , ,] = row;
-              nullable = true;
-            } else {
-              columnName = row.column_name;
-              columnType = row.column_type;
-              nullable = row.null === 'YES';
-            }
-
-            return {
-              name: columnName,
-              typeName: columnType,
-              ordinalPosition: index + 1,
-              primaryKeySequenceId: 0,
-              columnDisplaySize: 0,
-              scale: 0,
-              precision: 0,
-              columnProperties: [],
-              autoincrement: false,
-              primaryKey: false,
-              nullable,
-            };
-          })
-          .filter((col) => col.name && typeof col.name === 'string');
-      } catch {
-        return [];
-      }
-    }
-  }
-
-  async extractSchema(): Promise<{ tables: Table[] }> {
-    const [tableNames, viewNames] = await Promise.all([
-      this.getTables(),
-      this.getViews(),
-    ]);
-
-    const allTables: Table[] = [];
-
-    for (const tableName of tableNames) {
-      try {
-        const columns = await this.getDetailedColumns(tableName);
-        allTables.push({
-          name: tableName,
-          type: 'TABLE',
-          schema: this.schema,
-          columns,
-        });
-      } catch {
-        /* empty */
-      }
-    }
-
-    for (const viewName of viewNames) {
-      try {
-        const columns = await this.getDetailedColumns(viewName);
-        allTables.push({
-          name: viewName,
-          type: 'VIEW',
-          schema: this.schema,
-          columns,
-        });
-      } catch {
-        /* empty */
-      }
-    }
-
-    return { tables: allTables };
+  private async query(
+    connection: DuckDBConnection,
+    sql: string,
+  ): Promise<any[]> {
+    const reader = await connection.runAndReadAll(sql, [this.schema]);
+    return reader.getRowObjectsJS();
   }
 }

--- a/src/renderer/screens/sql/SchemaTreeViewerWithSchema.tsx
+++ b/src/renderer/screens/sql/SchemaTreeViewerWithSchema.tsx
@@ -44,13 +44,24 @@ export const SchemaTreeViewerWithSchema: React.FC<Props> = React.memo(
     ]);
 
     const filteredTables = React.useMemo(() => {
-      if (!filter) return tables;
       const lowerFilter = filter.toLowerCase();
-      return tables.filter(
-        (table) =>
-          table.name.toLowerCase().includes(lowerFilter) ||
-          table.schema.toLowerCase().includes(lowerFilter),
-      );
+      const seen = new Set<string>();
+
+      // Tree items are keyed by "schema.name", and the tree view throws if two
+      // items share an id, which would blank the whole screen. Drop repeats.
+      return tables.filter((table) => {
+        if (
+          filter &&
+          !table.name.toLowerCase().includes(lowerFilter) &&
+          !table.schema.toLowerCase().includes(lowerFilter)
+        ) {
+          return false;
+        }
+        const id = `${table.schema}.${table.name}`;
+        if (seen.has(id)) return false;
+        seen.add(id);
+        return true;
+      });
     }, [tables, filter]);
 
     const schemaMap = React.useMemo(() => {


### PR DESCRIPTION
## Problem

Expanding a schema in the SQL editor could blank the whole app, and views
were missing from the tree.

`extractSchema()` ran `getTables()` and `getViews()` concurrently, and each
opened its own DuckDB instance. DuckDB holds an exclusive lock on the
database file, so one of them lost the race:

- `getViews()` losing meant every view silently vanished from the tree.
- `getTables()` losing meant falling back to `SHOW TABLES`, which also
  returns views. Those views were then added a second time by `getViews()`,
  producing two tree items with the same `schema.name` id. MUI x-tree-view
  throws on duplicate ids, and with no error boundary above the SQL screen
  the renderer unmounted - white screen.

The children only mount on expand, which is why it took clicking a schema
to trigger it.

## Fix

- One connection for the whole extraction instead of one instance per query
  (was 2 + one per table, so 11 file opens for a 9-object schema; now 1).
- Tables and views come from a single `information_schema.tables` query and
  are classified by `table_type`, so an object cannot be collected twice.
  The `SHOW TABLES` fallback that conflated the two is gone.
- All columns fetch in one `information_schema.columns` query instead of one
  per table.
- Schema name is now a bound parameter rather than interpolated SQL.
- The schema tree skips duplicate `schema.name` pairs, so malformed input
  can't take the app down again.

## Testing

Verified against a real dbt DuckDB project: 9 objects, 4 correctly typed as
views, columns populated, no duplicates, identical across repeated runs.
Previously the same database returned 5 objects and no views. Confirmed in
the running app - schema expands, views appear with columns.

`tsc --noEmit` and eslint clean. Full unit and integration suites compared
against `dev`: no new failures.

## Note

The crash is likely Windows-only. Windows enforces file sharing per handle,
so the second open fails with a sharing violation; POSIX advisory locks
generally don't conflict with the same process. Reviewers on macOS may not
reproduce it. The duplicate-item guard and the reduction in file opens are
platform-independent wins regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DuckDB schema extraction for more consistent table, view, and column metadata.
  * Prevented duplicate tables from appearing in the schema tree.
  * Improved schema search filtering and eliminated repeated tree entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->