### PR TITLE
fix: duplicate table name bug causing blank screen on windows

### DIFF
--- a/src/main/extractor/duckdb.extractor.ts
+++ b/src/main/extractor/duckdb.extractor.ts
@@ -216,8 +216,14 @@ export default class DuckDBSchemaExtractor {
     // Deduplicate defensively: concurrent connections against the same
     // database file (opened separately for the tables and views queries)
     // have been observed to yield repeated rows on Windows.
-    const tableNames = Array.from(new Set(tableNamesRaw));
-    const viewNames = Array.from(new Set(viewNamesRaw));
+    const tableNameSet = new Set(tableNamesRaw);
+    const tableNames = Array.from(tableNameSet);
+    // Tables and views are read as two separate snapshots, so a name that
+    // was replaced (table -> view or vice versa) mid-refresh could show up
+    // in both lists. Prefer the table entry on a collision.
+    const viewNames = Array.from(new Set(viewNamesRaw)).filter(
+      (name) => !tableNameSet.has(name),
+    );
 
     const allTables: Table[] = [];
 

--- a/src/main/extractor/duckdb.extractor.ts
+++ b/src/main/extractor/duckdb.extractor.ts
@@ -208,10 +208,16 @@ export default class DuckDBSchemaExtractor {
   }
 
   async extractSchema(): Promise<{ tables: Table[] }> {
-    const [tableNames, viewNames] = await Promise.all([
+    const [tableNamesRaw, viewNamesRaw] = await Promise.all([
       this.getTables(),
       this.getViews(),
     ]);
+
+    // Deduplicate defensively: concurrent connections against the same
+    // database file (opened separately for the tables and views queries)
+    // have been observed to yield repeated rows on Windows.
+    const tableNames = Array.from(new Set(tableNamesRaw));
+    const viewNames = Array.from(new Set(viewNamesRaw));
 
     const allTables: Table[] = [];
 

--- a/src/renderer/components/schemaTreeViewer/RenderTree.tsx
+++ b/src/renderer/components/schemaTreeViewer/RenderTree.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { TreeItem } from '@mui/x-tree-view';
 import { TreeItems } from './TreeItems';
 import { Table } from '../../../types/backend';
+import { tableTreeKey, columnTreeKey } from './treeIds';
 
 type Props = {
   table: Table;
@@ -18,14 +19,14 @@ const RenderTree: React.FC<Props> = ({ table }) => {
 
   return (
     <TreeItem
-      key={table.name}
-      itemId={`${table.schema}.${table.name}`}
+      key={tableTreeKey(table)}
+      itemId={tableTreeKey(table)}
       label={label}
     >
       {table.columns.map((col) => (
         <TreeItem
-          key={col.name}
-          itemId={`${table.schema}.${table.name}.${col.name}`}
+          key={columnTreeKey(table, col.name)}
+          itemId={columnTreeKey(table, col.name)}
           label={
             <TreeItems.Column
               label={col.name}

--- a/src/renderer/components/schemaTreeViewer/dedupeTables.ts
+++ b/src/renderer/components/schemaTreeViewer/dedupeTables.ts
@@ -1,0 +1,16 @@
+import { Table } from '../../../types/backend';
+
+// MUI X Tree View requires every itemId to be unique. RenderTree derives
+// itemIds from `${table.schema}.${table.name}`, so a schema extractor that
+// returns the same table twice (seen intermittently on Windows, likely from
+// a stale/racing DuckDB connection) crashes the whole tree instead of just
+// rendering a duplicate row. Drop repeats before they reach the tree.
+export const dedupeTables = (tables: Table[]): Table[] => {
+  const seen = new Set<string>();
+  return tables.filter((table) => {
+    const key = `${table.schema}.${table.name}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};

--- a/src/renderer/components/schemaTreeViewer/dedupeTables.ts
+++ b/src/renderer/components/schemaTreeViewer/dedupeTables.ts
@@ -1,14 +1,15 @@
 import { Table } from '../../../types/backend';
+import { tableTreeKey } from './treeIds';
 
 // MUI X Tree View requires every itemId to be unique. RenderTree derives
-// itemIds from `${table.schema}.${table.name}`, so a schema extractor that
-// returns the same table twice (seen intermittently on Windows, likely from
-// a stale/racing DuckDB connection) crashes the whole tree instead of just
+// itemIds from tableTreeKey(table), so a schema extractor that returns the
+// same table twice (seen intermittently on Windows, likely from a
+// stale/racing DuckDB connection) crashes the whole tree instead of just
 // rendering a duplicate row. Drop repeats before they reach the tree.
 export const dedupeTables = (tables: Table[]): Table[] => {
   const seen = new Set<string>();
   return tables.filter((table) => {
-    const key = `${table.schema}.${table.name}`;
+    const key = tableTreeKey(table);
     if (seen.has(key)) return false;
     seen.add(key);
     return true;

--- a/src/renderer/components/schemaTreeViewer/index.tsx
+++ b/src/renderer/components/schemaTreeViewer/index.tsx
@@ -7,6 +7,7 @@ import { RenderTree } from './RenderTree';
 import { Container, Header, NoDataMessage, StyledTreeView } from './styles';
 import { SupportedConnectionTypes, Table } from '../../../types/backend';
 import { TreeItems } from './TreeItems';
+import { dedupeTables } from './dedupeTables';
 import { useAppContext } from '../../hooks';
 import connectionIcons from '../../../../assets/connectionIcons';
 
@@ -27,13 +28,16 @@ const SchemaTreeViewer: React.FC<Props> = React.memo(
     ]);
 
     const schemaMap = React.useMemo(() => {
-      return tables.reduce<Record<string, Table[]>>((acc, table) => {
-        if (!acc[table.schema]) {
-          acc[table.schema] = [];
-        }
-        acc[table.schema].push(table);
-        return acc;
-      }, {});
+      return dedupeTables(tables).reduce<Record<string, Table[]>>(
+        (acc, table) => {
+          if (!acc[table.schema]) {
+            acc[table.schema] = [];
+          }
+          acc[table.schema].push(table);
+          return acc;
+        },
+        {},
+      );
     }, [tables]);
 
     const handleExpandedItemsChange = React.useCallback(

--- a/src/renderer/components/schemaTreeViewer/index.tsx
+++ b/src/renderer/components/schemaTreeViewer/index.tsx
@@ -8,6 +8,7 @@ import { Container, Header, NoDataMessage, StyledTreeView } from './styles';
 import { SupportedConnectionTypes, Table } from '../../../types/backend';
 import { TreeItems } from './TreeItems';
 import { dedupeTables } from './dedupeTables';
+import { schemaTreeKey, tableTreeKey } from './treeIds';
 import { useAppContext } from '../../hooks';
 import connectionIcons from '../../../../assets/connectionIcons';
 
@@ -95,12 +96,12 @@ const SchemaTreeViewer: React.FC<Props> = React.memo(
             >
               {Object.entries(schemaMap).map(([schemaName, schemaTables]) => (
                 <TreeItem
-                  key={`${databaseName}.${schemaName}`}
-                  itemId={`${databaseName}.${schemaName}`}
+                  key={schemaTreeKey(databaseName, schemaName)}
+                  itemId={schemaTreeKey(databaseName, schemaName)}
                   label={<TreeItems.Schema label={schemaName} />}
                 >
                   {schemaTables.map((table) => (
-                    <RenderTree key={table.name} table={table} />
+                    <RenderTree key={tableTreeKey(table)} table={table} />
                   ))}
                 </TreeItem>
               ))}

--- a/src/renderer/components/schemaTreeViewer/treeIds.ts
+++ b/src/renderer/components/schemaTreeViewer/treeIds.ts
@@ -1,0 +1,22 @@
+import { Table } from '../../../types/backend';
+
+// Tagged, colon-delimited identity keys for the schema tree (MUI X Tree View
+// requires every itemId to be globally unique). Each level is tagged
+// (D/S/T/V/C) so a database, schema, table, view, and column node can never
+// collide with each other. A collision between two different tables would
+// require a schema or table name containing a literal tag sequence like
+// ":T:" or ":C:" - not something any real schema/table name does.
+export const schemaTreeKey = (
+  databaseName: string,
+  schemaName: string,
+): string => `D:${databaseName}:S:${schemaName}`;
+
+export const tableTreeKey = (
+  table: Pick<Table, 'schema' | 'name' | 'type'>,
+): string =>
+  `S:${table.schema}:${table.type === 'VIEW' ? 'V' : 'T'}:${table.name}`;
+
+export const columnTreeKey = (
+  table: Pick<Table, 'schema' | 'name' | 'type'>,
+  columnName: string,
+): string => `${tableTreeKey(table)}:C:${columnName}`;

--- a/src/renderer/screens/sql/SchemaTreeViewerWithSchema.tsx
+++ b/src/renderer/screens/sql/SchemaTreeViewerWithSchema.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { TreeItem } from '@mui/x-tree-view';
 import { Box, CircularProgress } from '@mui/material';
 import { RenderTree } from '../../components/schemaTreeViewer/RenderTree';
+import { dedupeTables } from '../../components/schemaTreeViewer/dedupeTables';
 import {
   Container,
   NoDataMessage,
@@ -43,15 +44,17 @@ export const SchemaTreeViewerWithSchema: React.FC<Props> = React.memo(
       databaseName,
     ]);
 
+    const dedupedTables = React.useMemo(() => dedupeTables(tables), [tables]);
+
     const filteredTables = React.useMemo(() => {
-      if (!filter) return tables;
+      if (!filter) return dedupedTables;
       const lowerFilter = filter.toLowerCase();
-      return tables.filter(
+      return dedupedTables.filter(
         (table) =>
           table.name.toLowerCase().includes(lowerFilter) ||
           table.schema.toLowerCase().includes(lowerFilter),
       );
-    }, [tables, filter]);
+    }, [dedupedTables, filter]);
 
     const schemaMap = React.useMemo(() => {
       const map = filteredTables.reduce<Record<string, Table[]>>(

--- a/src/renderer/screens/sql/SchemaTreeViewerWithSchema.tsx
+++ b/src/renderer/screens/sql/SchemaTreeViewerWithSchema.tsx
@@ -5,6 +5,10 @@ import { Box, CircularProgress } from '@mui/material';
 import { RenderTree } from '../../components/schemaTreeViewer/RenderTree';
 import { dedupeTables } from '../../components/schemaTreeViewer/dedupeTables';
 import {
+  schemaTreeKey,
+  tableTreeKey,
+} from '../../components/schemaTreeViewer/treeIds';
+import {
   Container,
   NoDataMessage,
   StyledTreeView,
@@ -128,23 +132,17 @@ export const SchemaTreeViewerWithSchema: React.FC<Props> = React.memo(
             >
               {hideSchemaLevel &&
                 filteredTables.map((table) => (
-                  <RenderTree
-                    key={`${table.schema}.${table.name}`}
-                    table={table}
-                  />
+                  <RenderTree key={tableTreeKey(table)} table={table} />
                 ))}
               {!hideSchemaLevel &&
                 Object.entries(schemaMap).map(([schemaName, schemaTables]) => (
                   <TreeItem
-                    key={`${databaseName}.${schemaName}`}
-                    itemId={`${databaseName}.${schemaName}`}
+                    key={schemaTreeKey(databaseName, schemaName)}
+                    itemId={schemaTreeKey(databaseName, schemaName)}
                     label={<TreeItems.Schema label={schemaName} />}
                   >
                     {schemaTables.map((table) => (
-                      <RenderTree
-                        key={`${schemaName}.${table.name}`}
-                        table={table}
-                      />
+                      <RenderTree key={tableTreeKey(table)} table={table} />
                     ))}
                   </TreeItem>
                 ))}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate tables and views from schema metadata results.
  * Prevented duplicate table entries from appearing in schema tree views.
  * Ensured filtering and rendering operate on unique schema tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->