### PR TITLE
enhance(sql-editor): move save and history buttons into the tab bar

### DIFF
--- a/src/renderer/components/sqlEditor/SqlEditorActions.tsx
+++ b/src/renderer/components/sqlEditor/SqlEditorActions.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { toast } from 'react-toastify';
+import { Box, Tooltip, IconButton } from '@mui/material';
+import { Save as SaveIcon } from '@mui/icons-material';
+import { QueryHistoryType } from '../../../types/frontend';
+import { QueryHistory } from './queryHistory';
+import { SaveQueryDialog } from './SaveQueryDialog';
+import { useCreateSavedQuery } from '../../controllers/savedQueries.controller';
+
+type Props = {
+  connectionId?: string;
+  query: string;
+  queryHistory: QueryHistoryType[];
+  onQuerySelect: (query: string) => void;
+};
+
+export const SqlEditorActions: React.FC<Props> = ({
+  connectionId,
+  query,
+  queryHistory,
+  onQuerySelect,
+}) => {
+  const [saveDialogOpen, setSaveDialogOpen] = React.useState(false);
+  const createQueryMutation = useCreateSavedQuery();
+
+  const handleSaveQuery = async (name: string) => {
+    if (!connectionId || !query.trim()) {
+      toast.error('No connection or query content');
+      return;
+    }
+    try {
+      await createQueryMutation.mutateAsync({
+        connectionId,
+        name,
+        query,
+      });
+      toast.success('Query saved successfully');
+    } catch (e) {
+      toast.error('Failed to save query');
+    }
+  };
+
+  if (!connectionId) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', flex: '0 0 auto' }}>
+      <Tooltip title="Save Query">
+        <span>
+          <IconButton
+            size="small"
+            onClick={() => setSaveDialogOpen(true)}
+            disabled={!query.trim()}
+          >
+            <SaveIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+      {queryHistory.length > 0 && (
+        <QueryHistory
+          size="small"
+          onQuerySelect={(qh) => onQuerySelect(qh.query)}
+          queryHistory={queryHistory}
+          connectionId={connectionId}
+        />
+      )}
+      <SaveQueryDialog
+        open={saveDialogOpen}
+        onClose={() => setSaveDialogOpen(false)}
+        onSave={handleSaveQuery}
+      />
+    </Box>
+  );
+};

--- a/src/renderer/components/sqlEditor/index.tsx
+++ b/src/renderer/components/sqlEditor/index.tsx
@@ -1,19 +1,15 @@
 import React, { useRef } from 'react';
 import { toast } from 'react-toastify';
 import type * as monacoType from 'monaco-editor';
-import { Box, Tooltip, IconButton } from '@mui/material';
-import { Save as SaveIcon } from '@mui/icons-material';
+import { Box } from '@mui/material';
 import { Inputs, RelativeContainer } from './styles';
 import { connectorsServices, projectsServices } from '../../services';
 import { DuckLakeService } from '../../services/duckLake.service';
 import { QueryHistoryType } from '../../../types/frontend';
 import { ConnectionInput, Project } from '../../../types/backend';
 import { SqlEditorComponent } from './editorComponent';
-import { QueryHistory } from './queryHistory';
 import { useAppContext } from '../../hooks';
 import { useSqlEditorBridge } from '../../controllers';
-import { SaveQueryDialog } from './SaveQueryDialog';
-import { useCreateSavedQuery } from '../../controllers/savedQueries.controller';
 
 type Props = {
   completions: Omit<monacoType.languages.CompletionItem, 'range'>[];
@@ -57,8 +53,6 @@ export const SqlEditor: React.FC<Props> = ({
   const editorRef = useRef<monacoType.editor.IStandaloneCodeEditor | null>(
     null,
   );
-  const [saveDialogOpen, setSaveDialogOpen] = React.useState(false);
-  const createQueryMutation = useCreateSavedQuery();
 
   // Determine if we're in connection-based mode
   const isConnectionMode = !!connectionId;
@@ -413,26 +407,6 @@ export const SqlEditor: React.FC<Props> = ({
     ],
   );
 
-  // Get filter ID for query history based on mode
-  const historyFilterId = isConnectionMode ? connectionId : selectedProject?.id;
-
-  const handleSaveQuery = async (name: string) => {
-    if (!connectionId || !queryContent.trim()) {
-      toast.error('No connection or query content');
-      return;
-    }
-    try {
-      await createQueryMutation.mutateAsync({
-        connectionId,
-        name,
-        query: queryContent,
-      });
-      toast.success('Query saved successfully');
-    } catch (e) {
-      toast.error('Failed to save query');
-    }
-  };
-
   return (
     <Inputs>
       <RelativeContainer>
@@ -445,43 +419,8 @@ export const SqlEditor: React.FC<Props> = ({
             onRunSelected={(lineQuery) => handleRunQuery(lineQuery)}
             isLoading={isLoading}
           />
-          <Box
-            sx={{
-              position: 'absolute',
-              top: -15,
-              right: -10,
-              margin: '20px',
-              display: 'flex',
-              alignItems: 'center',
-              zIndex: 10,
-            }}
-          >
-            {isConnectionMode && connectionId && (
-              <Tooltip title="Save Query">
-                <IconButton
-                  onClick={() => setSaveDialogOpen(true)}
-                  disabled={!queryContent.trim()}
-                >
-                  <SaveIcon />
-                </IconButton>
-              </Tooltip>
-            )}
-            {queryHistory.length > 0 && historyFilterId && (
-              <QueryHistory
-                onQuerySelect={(qh) => handleQueryContentChange(qh.query)}
-                queryHistory={queryHistory}
-                projectId={isConnectionMode ? undefined : selectedProject?.id}
-                connectionId={isConnectionMode ? connectionId : undefined}
-              />
-            )}
-          </Box>
         </Box>
       </RelativeContainer>
-      <SaveQueryDialog
-        open={saveDialogOpen}
-        onClose={() => setSaveDialogOpen(false)}
-        onSave={handleSaveQuery}
-      />
     </Inputs>
   );
 };

--- a/src/renderer/components/sqlEditor/queryHistory/index.tsx
+++ b/src/renderer/components/sqlEditor/queryHistory/index.tsx
@@ -51,6 +51,7 @@ type Props = {
   queryHistory: QueryHistoryType[];
   projectId?: string;
   connectionId?: string;
+  size?: 'small' | 'medium';
 };
 
 type ToolbarProps = {
@@ -298,6 +299,7 @@ const QueryHistory: React.FC<Props> = ({
   onQuerySelect,
   projectId,
   connectionId,
+  size = 'medium',
 }) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedQueryHistory, setSelectedQueryHistory] =
@@ -452,8 +454,8 @@ const QueryHistory: React.FC<Props> = ({
   return (
     <div>
       <Tooltip title="Query History">
-        <IconButton onClick={handleClick}>
-          <History />
+        <IconButton size={size} onClick={handleClick}>
+          <History fontSize={size === 'small' ? 'small' : 'medium'} />
         </IconButton>
       </Tooltip>
       <Menu

--- a/src/renderer/components/sqlTabs/index.tsx
+++ b/src/renderer/components/sqlTabs/index.tsx
@@ -103,6 +103,7 @@ interface SqlTabManagerProps {
   onSelect: (tabId: SqlTabId) => void;
   onClose: (tabId: SqlTabId) => void;
   onReorder: (fromIndex: number, toIndex: number) => void;
+  actions?: React.ReactNode;
 }
 
 type DragState = {
@@ -116,6 +117,7 @@ export const SqlTabManager: React.FC<SqlTabManagerProps> = ({
   onSelect,
   onClose,
   onReorder,
+  actions,
 }) => {
   const [dragState, setDragState] = React.useState<DragState>({
     tabId: null,
@@ -261,6 +263,7 @@ export const SqlTabManager: React.FC<SqlTabManagerProps> = ({
           {dragState.overTabId === null && dragState.tabId && <DropIndicator />}
         </TabsContainer>
       )}
+      {actions}
     </SqlTabBar>
   );
 };

--- a/src/renderer/screens/sql/index.tsx
+++ b/src/renderer/screens/sql/index.tsx
@@ -1270,6 +1270,7 @@ const Sql = () => {
                     actions={
                       activeTab && (
                         <SqlEditorActions
+                          key={activeTab.id}
                           connectionId={activeTab.connectionId}
                           query={activeTab.query}
                           queryHistory={queryHistory}

--- a/src/renderer/screens/sql/index.tsx
+++ b/src/renderer/screens/sql/index.tsx
@@ -65,6 +65,7 @@ import {
 } from '../../controllers';
 import { SchemaTreeViewerWithSchema } from './SchemaTreeViewerWithSchema';
 import { SavedQueriesList } from '../../components/sqlEditor/SavedQueriesList';
+import { SqlEditorActions } from '../../components/sqlEditor/SqlEditorActions';
 import connectionIcons, {
   defaultIcon,
 } from '../../../../assets/connectionIcons';
@@ -1266,6 +1267,25 @@ const Sql = () => {
                     onSelect={switchTab}
                     onClose={closeTab}
                     onReorder={reorderTabs}
+                    actions={
+                      activeTab && (
+                        <SqlEditorActions
+                          connectionId={activeTab.connectionId}
+                          query={activeTab.query}
+                          queryHistory={queryHistory}
+                          onQuerySelect={(query) => {
+                            updateTabQuery(activeTab.id, query);
+                            connectorsServices
+                              .updateConnectionQuery(
+                                activeTab.connectionId,
+                                query,
+                              )
+                              .then(() => markTabSaved(activeTab.id))
+                              .catch(() => {});
+                          }}
+                        />
+                      )
+                    }
                   />
 
                   {/* Main Content */}


### PR DESCRIPTION
The Save Query and Query History buttons were positioned on top of the editor
and overlapped the SQL text. They now sit right-aligned in the tab bar.

- Moved the buttons, save dialog and save mutation into a new `SqlEditorActions`
- Added an optional `actions` slot to `SqlTabManager`
- Behavior is unchanged: same buttons, same conditions, history pick still saves
  through to the connection's stored query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added save-query controls and query history to the SQL editor toolbar.
  * Users can save non-empty queries when a connection is selected, with success or failure notifications.
  * Selecting a previous query updates the active SQL tab and preserves its saved state.
  * Added compact and standard display sizes for query history controls.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->