### PR TITLE
feat(settings): add documentation link

### DIFF
--- a/src/renderer/screens/settings/index.tsx
+++ b/src/renderer/screens/settings/index.tsx
@@ -269,7 +269,11 @@ const Settings: React.FC = () => {
                           element.externalUrl
                             ? (e) => {
                                 e.preventDefault();
-                                window.open(element.externalUrl, '_blank');
+                                window.open(
+                                  element.externalUrl,
+                                  '_blank',
+                                  'noopener,noreferrer',
+                                );
                               }
                             : undefined
                         }

--- a/src/renderer/screens/settings/index.tsx
+++ b/src/renderer/screens/settings/index.tsx
@@ -10,7 +10,7 @@ import {
   ListItemIcon,
   ListItemText,
 } from '@mui/material';
-import { DarkMode, LightMode } from '@mui/icons-material';
+import { DarkMode, LightMode, OpenInNew } from '@mui/icons-material';
 import { useLocation } from 'react-router-dom';
 import { useColorScheme } from '@mui/material/styles';
 import AppsIcon from '@mui/icons-material/Apps';
@@ -265,12 +265,21 @@ const Settings: React.FC = () => {
                   {category.items.map((element) => (
                     <StyledSettingsNavLink key={element.text} to={element.path}>
                       <ListItem
+                        onClick={
+                          element.externalUrl
+                            ? (e) => {
+                                e.preventDefault();
+                                window.open(element.externalUrl, '_blank');
+                              }
+                            : undefined
+                        }
                         sx={{
                           cursor: 'pointer',
                           borderRadius: 1,
                           mb: 0,
                           width: '100%',
                           backgroundColor:
+                            !element.externalUrl &&
                             location.pathname === element.path
                               ? theme.palette.divider
                               : 'transparent',
@@ -280,6 +289,7 @@ const Settings: React.FC = () => {
                           <element.icon
                             fontSize="small"
                             color={
+                              !element.externalUrl &&
                               location.pathname === element.path
                                 ? 'primary'
                                 : 'inherit'
@@ -287,6 +297,11 @@ const Settings: React.FC = () => {
                           />
                         </ListItemIcon>
                         <ListItemText primary={element.text} />
+                        {element.externalUrl && (
+                          <OpenInNew
+                            sx={{ fontSize: 13, opacity: 0.4, mr: 2 }}
+                          />
+                        )}
                       </ListItem>
                     </StyledSettingsNavLink>
                   ))}

--- a/src/renderer/screens/settings/settingsElements.tsx
+++ b/src/renderer/screens/settings/settingsElements.tsx
@@ -8,6 +8,7 @@ import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import ChecklistIcon from '@mui/icons-material/Checklist';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import CodeIcon from '@mui/icons-material/Code';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
 import { SvgIconComponent } from '@mui/icons-material';
 import React from 'react';
 import { Icon } from '../../components/icon';
@@ -43,6 +44,7 @@ export interface SettingsSidebarElement {
   icon: SvgIconComponent;
   text: string;
   path: string;
+  externalUrl?: string;
 }
 
 export interface SettingsSidebarCategory {
@@ -119,6 +121,12 @@ export const settingsSidebarCategories: SettingsSidebarCategory[] = [
   {
     label: '',
     items: [
+      {
+        icon: MenuBookIcon,
+        text: 'Documentation',
+        path: '/app/settings/_external_docs',
+        externalUrl: 'https://docs.rosettalabs.ai/',
+      },
       {
         icon: InfoIcon,
         text: 'About',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Documentation link to the Settings sidebar.
  * Documentation opens in a new browser tab and is marked with an external-link icon.
  * External links use safe browser-opening behavior and do not trigger in-app navigation.
  * External links are no longer highlighted as active in the app navigation, keeping route selection accurate while browsing external resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->