### PR TITLE
fix(iceberg): add missing 'resources' segment to packaged bridge path

### DIFF
--- a/src/main/services/icebergDatalake.service.ts
+++ b/src/main/services/icebergDatalake.service.ts
@@ -158,7 +158,12 @@ export class IcebergDatalakeService {
 
   private static getBridgePath(): string {
     if (app.isPackaged) {
-      return path.join(process.resourcesPath, 'python', 'iceberg_bridge.py');
+      return path.join(
+        process.resourcesPath,
+        'resources',
+        'python',
+        'iceberg_bridge.py',
+      );
     }
     return path.join(
       __dirname,


### PR DESCRIPTION
getBridgePath() resolved to process.resourcesPath/python/iceberg_bridge.py in packaged builds. electron-builder's extraResources preserves the source directory name, so the actual path is process.resourcesPath/resources/python/ iceberg_bridge.py on all platforms. Fixes bridge not found error on Linux (and would affect macOS/Windows packaged builds equally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed packaged application behavior by correcting the path used to locate the Python bridge script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->