### PR TITLE
added: export import notebook to include connection

### DIFF
--- a/src/main/ipcHandlers/notebooks.ipcHandlers.ts
+++ b/src/main/ipcHandlers/notebooks.ipcHandlers.ts
@@ -76,6 +76,14 @@ export function registerNotebooksHandlers() {
     return NotebooksService.selectNotebookFile();
   });
 
+  // Peek at an import file (check for embedded connection details) before importing
+  ipcMain.handle(
+    'notebooks:peekImportFile',
+    async (_event, filePath: string) => {
+      return NotebooksService.peekImportFile(filePath);
+    },
+  );
+
   // Import notebook
   ipcMain.handle(
     'notebooks:import',

--- a/src/main/services/notebooks.service.ts
+++ b/src/main/services/notebooks.service.ts
@@ -8,7 +8,12 @@ import { app } from 'electron';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
-import { Notebook, NotebookCell, CellOutput } from '../../types/notebooks';
+import {
+  Notebook,
+  NotebookCell,
+  CellOutput,
+  NotebookImportPreview,
+} from '../../types/notebooks';
 import ConnectorsService from './connectors.service';
 import DuckLakeService from './duckLake.service';
 
@@ -485,6 +490,63 @@ export class NotebooksService {
       // eslint-disable-next-line no-console
       console.error(error);
       throw error;
+    }
+  }
+
+  /**
+   * Peek at a notebook export JSON file without importing it, so the
+   * renderer can ask the user whether to also import the embedded
+   * connection details (if any) before committing to the import.
+   */
+  static async peekImportFile(
+    filePath: string,
+  ): Promise<NotebookImportPreview> {
+    try {
+      const fileContent = await fs.readFile(filePath, 'utf-8');
+
+      const fileSizeInMB =
+        Buffer.byteLength(fileContent, 'utf-8') / (1024 * 1024);
+      if (fileSizeInMB > 100) {
+        throw new Error(
+          `File is too large (${fileSizeInMB.toFixed(1)}MB). Maximum size is 100MB.`,
+        );
+      }
+
+      let importedData: any;
+      try {
+        importedData = JSON.parse(fileContent);
+      } catch (parseError) {
+        throw new Error(
+          'Invalid JSON file - unable to parse. The file may be corrupted or too large.',
+        );
+      }
+
+      if (!importedData) {
+        throw new Error('Empty JSON file');
+      }
+
+      const isBulk =
+        Array.isArray(importedData.notebooks) &&
+        importedData.notebooks.length > 0;
+
+      const hasValidConnection =
+        importedData.connection &&
+        typeof importedData.connection === 'object' &&
+        typeof importedData.connection.type === 'string' &&
+        typeof importedData.connection.name === 'string';
+
+      return {
+        isBulk,
+        notebookCount: isBulk ? importedData.notebooks.length : 1,
+        connection: hasValidConnection ? importedData.connection : undefined,
+        connectionName: hasValidConnection
+          ? importedData.connection.name
+          : importedData.connectionName,
+      };
+    } catch (error) {
+      throw new Error(
+        `Failed to read import file: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
     }
   }
 

--- a/src/main/services/notebooks.service.ts
+++ b/src/main/services/notebooks.service.ts
@@ -73,6 +73,29 @@ function limitCellOutputData(output: CellOutput): CellOutput {
   return output;
 }
 
+// Serialize all reads-then-writes to a given notebook file. Without this,
+// concurrent saves (content debounce, add/delete/duplicate cell, run-cell
+// output) each read the file, compute an update, and write back — if two
+// overlap, whichever write lands last wins and silently discards the other's
+// change (e.g. a newly added cell, or a just-typed edit).
+const notebookWriteQueues = new Map<string, Promise<unknown>>();
+
+function withNotebookWriteLock<T>(
+  notebookPath: string,
+  task: () => Promise<T>,
+): Promise<T> {
+  const previous = notebookWriteQueues.get(notebookPath) ?? Promise.resolve();
+  const run = previous.then(task, task);
+  notebookWriteQueues.set(
+    notebookPath,
+    run.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return run;
+}
+
 // Validate and sanitize pagination inputs
 const MAX_PAGE_LIMIT = 1000;
 
@@ -368,35 +391,38 @@ export class NotebooksService {
       cells?: NotebookCell[];
     },
   ): Promise<Notebook> {
-    try {
-      const connectionKey = normalizeConnectionKey(connectionId);
-      const notebook = await this.getNotebook(connectionId, notebookId);
+    const connectionKey = normalizeConnectionKey(connectionId);
+    const notebookPath = getNotebookPath(connectionKey, notebookId);
 
-      if (!notebook) {
-        throw new Error(`Notebook ${notebookId} not found`);
+    return withNotebookWriteLock(notebookPath, async () => {
+      try {
+        const notebook = await this.getNotebook(connectionId, notebookId);
+
+        if (!notebook) {
+          throw new Error(`Notebook ${notebookId} not found`);
+        }
+
+        // Only include defined properties in the update
+        const updatedNotebook: Notebook = {
+          ...notebook,
+          ...(updates.name !== undefined && { name: updates.name }),
+          ...(updates.description !== undefined && {
+            description: updates.description,
+          }),
+          ...(updates.cells !== undefined && { cells: updates.cells }),
+          updatedAt: new Date().toISOString(),
+          cellCount: updates.cells?.length ?? notebook.cellCount,
+        };
+
+        await writeNotebookFile(notebookPath, updatedNotebook);
+
+        return updatedNotebook;
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(error);
+        throw error;
       }
-
-      // Only include defined properties in the update
-      const updatedNotebook: Notebook = {
-        ...notebook,
-        ...(updates.name !== undefined && { name: updates.name }),
-        ...(updates.description !== undefined && {
-          description: updates.description,
-        }),
-        ...(updates.cells !== undefined && { cells: updates.cells }),
-        updatedAt: new Date().toISOString(),
-        cellCount: updates.cells?.length ?? notebook.cellCount,
-      };
-
-      const notebookPath = getNotebookPath(connectionKey, notebookId);
-      await writeNotebookFile(notebookPath, updatedNotebook);
-
-      return updatedNotebook;
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-      throw error;
-    }
+    });
   }
 
   /**
@@ -1171,24 +1197,37 @@ export class NotebooksService {
     cellId: string,
     output: CellOutput,
   ): Promise<void> {
-    try {
-      const notebook = await this.getNotebook(connectionId, notebookId);
-      if (!notebook) return;
+    const connectionKey = normalizeConnectionKey(connectionId);
+    const notebookPath = getNotebookPath(connectionKey, notebookId);
 
-      // Limit output data size to prevent massive files
-      const limitedOutput = limitCellOutputData(output);
+    // Read, merge, and write inside the same lock updateNotebook uses for
+    // this file (rather than delegating to updateNotebook, which would try
+    // to re-acquire the lock this call already holds and deadlock).
+    await withNotebookWriteLock(notebookPath, async () => {
+      try {
+        const notebook = await this.getNotebook(connectionId, notebookId);
+        if (!notebook) return;
 
-      const updatedCells = notebook.cells.map((cell) =>
-        cell.id === cellId ? { ...cell, output: limitedOutput } : cell,
-      );
+        // Limit output data size to prevent massive files
+        const limitedOutput = limitCellOutputData(output);
 
-      await this.updateNotebook(connectionId, notebookId, {
-        cells: updatedCells,
-      });
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-    }
+        const updatedCells = notebook.cells.map((cell) =>
+          cell.id === cellId ? { ...cell, output: limitedOutput } : cell,
+        );
+
+        const updatedNotebook: Notebook = {
+          ...notebook,
+          cells: updatedCells,
+          updatedAt: new Date().toISOString(),
+          cellCount: updatedCells.length,
+        };
+
+        await writeNotebookFile(notebookPath, updatedNotebook);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(error);
+      }
+    });
   }
 
   /**

--- a/src/renderer/components/notebook/ExportNotebookDialog.tsx
+++ b/src/renderer/components/notebook/ExportNotebookDialog.tsx
@@ -1,0 +1,95 @@
+/**
+ * Export Notebook Dialog
+ * Confirms a notebook (or bulk) export and offers to include full
+ * connection details (including credentials) in the exported JSON.
+ */
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  FormControlLabel,
+  Checkbox,
+  Alert,
+  Tooltip,
+} from '@mui/material';
+
+interface ExportNotebookDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (includeConnection: boolean) => void;
+  /** e.g. "notebook \"My Notebook\"" or "3 notebooks" */
+  subject: string;
+  connectionName?: string;
+  /** Disable the checkbox for connection types that can't be exported this way (e.g. DuckLake instances) */
+  connectionExportDisabled?: boolean;
+}
+
+export const ExportNotebookDialog: React.FC<ExportNotebookDialogProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  subject,
+  connectionName,
+  connectionExportDisabled,
+}) => {
+  const [includeConnection, setIncludeConnection] = useState(false);
+
+  const handleClose = () => {
+    setIncludeConnection(false);
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    onConfirm(includeConnection);
+    setIncludeConnection(false);
+  };
+
+  const checkbox = (
+    <FormControlLabel
+      control={
+        <Checkbox
+          checked={includeConnection}
+          disabled={connectionExportDisabled}
+          onChange={(e) => setIncludeConnection(e.target.checked)}
+        />
+      }
+      label={`Include connection details${connectionName ? ` for "${connectionName}"` : ''}`}
+    />
+  );
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Export {subject}</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 1 }}>
+          Export {subject} as a JSON file.
+        </DialogContentText>
+        {connectionExportDisabled ? (
+          <Tooltip title="Not available for this connection type">
+            <span>{checkbox}</span>
+          </Tooltip>
+        ) : (
+          checkbox
+        )}
+        {includeConnection && !connectionExportDisabled && (
+          <Alert severity="warning" sx={{ mt: 1 }}>
+            The connection, including its credentials, will be written to the
+            file in plain text. Only share this file with people you trust.
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleConfirm} variant="contained">
+          Export
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ExportNotebookDialog;

--- a/src/renderer/components/notebook/ImportConnectionDialog.tsx
+++ b/src/renderer/components/notebook/ImportConnectionDialog.tsx
@@ -1,0 +1,96 @@
+/**
+ * Import Connection Dialog
+ * Shown when an imported notebook export JSON includes embedded
+ * connection details, letting the user choose whether to create that
+ * connection (and import the notebook(s) onto it) or use the currently
+ * active connection instead.
+ */
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  FormControlLabel,
+  Checkbox,
+  Typography,
+} from '@mui/material';
+
+interface ImportConnectionDialogProps {
+  open: boolean;
+  connectionName?: string;
+  connectionType?: string;
+  notebookCount: number;
+  /** Whether there's a currently active connection the user can import onto instead */
+  hasActiveConnection: boolean;
+  onClose: () => void;
+  onConfirm: (importConnection: boolean) => void;
+}
+
+export const ImportConnectionDialog: React.FC<ImportConnectionDialogProps> = ({
+  open,
+  connectionName,
+  connectionType,
+  notebookCount,
+  hasActiveConnection,
+  onClose,
+  onConfirm,
+}) => {
+  const [importConnection, setImportConnection] = useState(true);
+
+  // Force-enable when there's no fallback connection to import onto
+  useEffect(() => {
+    if (!hasActiveConnection) {
+      setImportConnection(true);
+    }
+  }, [hasActiveConnection, open]);
+
+  const handleConfirm = () => {
+    onConfirm(importConnection);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Import Connection</DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 1 }}>
+          This file includes connection details for &quot;{connectionName}
+          &quot;{connectionType ? ` (${connectionType})` : ''}, in addition to{' '}
+          {notebookCount} notebook{notebookCount > 1 ? 's' : ''}.
+        </DialogContentText>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={importConnection}
+              disabled={!hasActiveConnection}
+              onChange={(e) => setImportConnection(e.target.checked)}
+            />
+          }
+          label="Also import this connection, and open the notebook(s) on it"
+        />
+        {!hasActiveConnection && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            No connection is currently selected, so the connection from this
+            file must be imported to continue.
+          </Typography>
+        )}
+        {hasActiveConnection && !importConnection && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            The notebook(s) will be imported onto the currently selected
+            connection instead.
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleConfirm} variant="contained">
+          Import
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ImportConnectionDialog;

--- a/src/renderer/components/notebook/NotebookEditor.tsx
+++ b/src/renderer/components/notebook/NotebookEditor.tsx
@@ -39,14 +39,19 @@ import {
   useDeleteNotebook,
   useDuplicateNotebook,
 } from '../../controllers/notebooks.controller';
+import { useGetConnections } from '../../controllers';
 import {
   NotebookCell as NotebookCellType,
   Notebook,
 } from '../../../types/notebooks';
+import { ConnectionInput } from '../../../types/backend';
 import { NotebookToolbar } from './NotebookToolbar';
 import { NotebookCell } from './NotebookCell';
+import { ExportNotebookDialog } from './ExportNotebookDialog';
 import { useSchemaForConnection, useMonacoAutocomplete } from '../../hooks';
 import { useNotebookBridge } from '../../hooks/useNotebookBridge';
+import useSecureStorage from '../../hooks/useSecureStorage';
+import { resolveConnectionCredentials } from '../../utils/notebookConnectionTransfer';
 
 // Module-level singleton for SQL completion provider
 let sharedCompletionProvider: any = null;
@@ -84,8 +89,14 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [deleteAllDialogOpen, setDeleteAllDialogOpen] = useState(false);
   const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
   const [newNotebookName, setNewNotebookName] = useState('');
   const [duplicateNotebookName, setDuplicateNotebookName] = useState('');
+
+  const { data: connections = [] } = useGetConnections();
+  const secureStorage = useSecureStorage();
+  const activeConnection = connections.find((c) => c.id === connectionId);
+  const isDuckLakeConnection = connectionId.startsWith('ducklake-');
 
   // Local state for cells to enable immediate UI updates
   const [localCells, setLocalCells] = useState<NotebookCellType[]>([]);
@@ -474,31 +485,57 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
 
   const handleExport = useCallback(() => {
     if (!notebook) return;
-
-    // Create export data without cell output data (to keep file size small)
-    const exportData = {
-      ...notebook,
-      cells: notebook.cells.map((cell) => ({
-        ...cell,
-        output: cell.output
-          ? {
-              ...cell.output,
-              data: [], // Remove data array to reduce file size
-            }
-          : undefined,
-      })),
-    };
-
-    // Export as JSON
-    const dataStr = JSON.stringify(exportData, null, 2);
-    const dataBlob = new Blob([dataStr], { type: 'application/json' });
-    const url = URL.createObjectURL(dataBlob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `${notebook.name}.json`;
-    link.click();
-    URL.revokeObjectURL(url);
+    setExportDialogOpen(true);
   }, [notebook]);
+
+  const handleExportConfirm = useCallback(
+    async (includeConnection: boolean) => {
+      setExportDialogOpen(false);
+      if (!notebook) return;
+
+      let connectionDetails: ConnectionInput | undefined;
+      if (includeConnection && activeConnection && !isDuckLakeConnection) {
+        connectionDetails = await resolveConnectionCredentials(
+          activeConnection.connection as ConnectionInput,
+          secureStorage,
+        );
+      }
+
+      // Create export data without cell output data (to keep file size small)
+      const exportData = {
+        ...notebook,
+        connectionId,
+        connectionName: activeConnection?.connection.name,
+        connection: connectionDetails,
+        cells: notebook.cells.map((cell) => ({
+          ...cell,
+          output: cell.output
+            ? {
+                ...cell.output,
+                data: [], // Remove data array to reduce file size
+              }
+            : undefined,
+        })),
+      };
+
+      // Export as JSON
+      const dataStr = JSON.stringify(exportData, null, 2);
+      const dataBlob = new Blob([dataStr], { type: 'application/json' });
+      const url = URL.createObjectURL(dataBlob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${notebook.name}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+    },
+    [
+      notebook,
+      connectionId,
+      activeConnection,
+      isDuckLakeConnection,
+      secureStorage,
+    ],
+  );
 
   const handleRename = useCallback(() => {
     if (!notebook) return;
@@ -990,6 +1027,16 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* Export Notebook Dialog */}
+      <ExportNotebookDialog
+        open={exportDialogOpen}
+        onClose={() => setExportDialogOpen(false)}
+        onConfirm={handleExportConfirm}
+        subject={`notebook "${notebook?.name ?? ''}"`}
+        connectionName={activeConnection?.connection.name}
+        connectionExportDisabled={isDuckLakeConnection || !activeConnection}
+      />
 
       {/* Run All Backdrop */}
       <Backdrop

--- a/src/renderer/components/notebook/NotebookEditor.tsx
+++ b/src/renderer/components/notebook/NotebookEditor.tsx
@@ -58,6 +58,17 @@ import { resolveConnectionCredentials } from '../../utils/notebookConnectionTran
 let sharedCompletionProvider: any = null;
 const completionsRefSingleton = { current: [] as any[] };
 
+const notebookSaveFlushers = new Map<string, () => Promise<void>>();
+
+export async function flushNotebookPendingSave(
+  notebookId: string,
+): Promise<void> {
+  const flush = notebookSaveFlushers.get(notebookId);
+  if (flush) {
+    await flush();
+  }
+}
+
 interface NotebookEditorProps {
   instanceId: string; // This is actually the connectionId
   notebookId: string;
@@ -102,6 +113,7 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
   // Local state for cells to enable immediate UI updates
   const [localCells, setLocalCells] = useState<NotebookCellType[]>([]);
   const updateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const localCellsRef = useRef<NotebookCellType[]>([]);
 
   // Cancel pending debounced save to prevent stale timeouts from overwriting structural edits
   const cancelPendingCellSave = useCallback(() => {
@@ -110,6 +122,26 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
       updateTimeoutRef.current = null;
     }
   }, []);
+
+  const flushPendingSave = useCallback(async () => {
+    if (!updateTimeoutRef.current) return;
+    clearTimeout(updateTimeoutRef.current);
+    updateTimeoutRef.current = null;
+    await updateNotebook.mutateAsync({
+      connectionId,
+      notebookId,
+      cells: localCellsRef.current,
+    });
+  }, [connectionId, notebookId, updateNotebook]);
+
+  // Register this editor's flush barrier so the parent screen can drain pending
+  // saves ahead of an export.
+  useEffect(() => {
+    notebookSaveFlushers.set(notebookId, flushPendingSave);
+    return () => {
+      notebookSaveFlushers.delete(notebookId);
+    };
+  }, [notebookId, flushPendingSave]);
 
   const { data: schemaData } = useSchemaForConnection(connectionId);
   const completions = useMonacoAutocomplete(
@@ -156,6 +188,10 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
       setLocalCells(notebook.cells);
     }
   }, [notebook?.cells]);
+
+  useEffect(() => {
+    localCellsRef.current = localCells;
+  }, [localCells]);
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -501,6 +537,7 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
           secureStorage,
         );
       }
+      await flushNotebookPendingSave(notebookId);
 
       // Fetch fresh from disk instead of the notebook detail cache, which is
       // only refreshed on mount or after running a cell — not after simply

--- a/src/renderer/components/notebook/NotebookEditor.tsx
+++ b/src/renderer/components/notebook/NotebookEditor.tsx
@@ -40,6 +40,7 @@ import {
   useDuplicateNotebook,
 } from '../../controllers/notebooks.controller';
 import { useGetConnections } from '../../controllers';
+import { notebooksService } from '../../services/notebooks.service';
 import {
   NotebookCell as NotebookCellType,
   Notebook,
@@ -501,13 +502,20 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
         );
       }
 
+      // Fetch fresh from disk instead of the notebook detail cache, which is
+      // only refreshed on mount or after running a cell — not after simply
+      // adding/editing one — and can be stale by the time of export.
+      const freshNotebook =
+        (await notebooksService.getNotebook(connectionId, notebookId)) ??
+        notebook;
+
       // Create export data without cell output data (to keep file size small)
       const exportData = {
-        ...notebook,
+        ...freshNotebook,
         connectionId,
         connectionName: activeConnection?.connection.name,
         connection: connectionDetails,
-        cells: notebook.cells.map((cell) => ({
+        cells: freshNotebook.cells.map((cell) => ({
           ...cell,
           output: cell.output
             ? {
@@ -531,6 +539,7 @@ export const NotebookEditor: React.FC<NotebookEditorProps> = ({
     [
       notebook,
       connectionId,
+      notebookId,
       activeConnection,
       isDuckLakeConnection,
       secureStorage,

--- a/src/renderer/components/notebook/index.ts
+++ b/src/renderer/components/notebook/index.ts
@@ -3,7 +3,7 @@
  * Exports all notebook-related components
  */
 
-export { NotebookEditor } from './NotebookEditor';
+export { NotebookEditor, flushNotebookPendingSave } from './NotebookEditor';
 export { NotebookCell } from './NotebookCell';
 export { SQLCell } from './SQLCell';
 export { MarkdownCell } from './MarkdownCell';

--- a/src/renderer/controllers/connectors.controller.ts
+++ b/src/renderer/controllers/connectors.controller.ts
@@ -20,6 +20,11 @@ import type {
 } from '../../types/ipc';
 import { QUERY_KEYS } from '../config/constants';
 import { connectorsServices } from '../services';
+import useSecureStorage from '../hooks/useSecureStorage';
+import {
+  getUniqueConnectionName,
+  storeImportedConnectionCredentials,
+} from '../utils/notebookConnectionTransfer';
 
 export const useGetConnections = (
   includeDataLake?: boolean,
@@ -128,6 +133,56 @@ export const useDeleteConnection = (
       await queryClient.invalidateQueries([QUERY_KEYS.GET_PROJECTS]);
       await queryClient.invalidateQueries([QUERY_KEYS.GET_SELECTED_PROJECT]);
       queryClient.removeQueries([QUERY_KEYS.GET_PROJECT_BY_ID]);
+      onCustomSuccess?.(...args);
+    },
+    onError: (...args) => {
+      onCustomError?.(...args);
+    },
+  });
+};
+
+/**
+ * Persist a connection embedded in an imported notebook export JSON file
+ * (see notebooks export "Include connection details" option). Dedupes the
+ * connection name against existing connections and writes credentials to
+ * secure storage the same way the connection forms do on save.
+ */
+export const useImportConnectionFromNotebook = (
+  customOptions?: UseMutationOptions<
+    { id: string; name: string },
+    CustomError,
+    ConnectionInput
+  >,
+): UseMutationResult<
+  { id: string; name: string },
+  CustomError,
+  ConnectionInput
+> => {
+  const { onSuccess: onCustomSuccess, onError: onCustomError } =
+    customOptions || {};
+  const queryClient = useQueryClient();
+  const secureStorage = useSecureStorage();
+
+  return useMutation({
+    mutationFn: async (connection: ConnectionInput) => {
+      const existingConnections =
+        await connectorsServices.listConnections(true);
+      const uniqueName = getUniqueConnectionName(
+        connection.name,
+        existingConnections,
+      );
+      const finalConnection: ConnectionInput = {
+        ...connection,
+        name: uniqueName,
+      };
+
+      const id = await connectorsServices.saveConnection(finalConnection);
+      await storeImportedConnectionCredentials(finalConnection, secureStorage);
+
+      return { id, name: uniqueName };
+    },
+    onSuccess: async (...args) => {
+      await queryClient.invalidateQueries([QUERY_KEYS.GET_CONNECTIONS]);
       onCustomSuccess?.(...args);
     },
     onError: (...args) => {

--- a/src/renderer/controllers/connectors.controller.ts
+++ b/src/renderer/controllers/connectors.controller.ts
@@ -24,6 +24,7 @@ import useSecureStorage from '../hooks/useSecureStorage';
 import {
   getUniqueConnectionName,
   storeImportedConnectionCredentials,
+  deleteImportedConnectionCredentials,
 } from '../utils/notebookConnectionTransfer';
 
 export const useGetConnections = (
@@ -176,8 +177,24 @@ export const useImportConnectionFromNotebook = (
         name: uniqueName,
       };
 
-      const id = await connectorsServices.saveConnection(finalConnection);
-      await storeImportedConnectionCredentials(finalConnection, secureStorage);
+      let id: string | undefined;
+      try {
+        id = await connectorsServices.saveConnection(finalConnection);
+        await storeImportedConnectionCredentials(
+          finalConnection,
+          secureStorage,
+        );
+      } catch (err) {
+        const rollbacks: Promise<void>[] = [];
+        if (id) {
+          rollbacks.push(connectorsServices.deleteConnection(id));
+        }
+        rollbacks.push(
+          deleteImportedConnectionCredentials(finalConnection, secureStorage),
+        );
+        await Promise.allSettled(rollbacks);
+        throw err;
+      }
 
       return { id, name: uniqueName };
     },

--- a/src/renderer/controllers/notebooks.controller.ts
+++ b/src/renderer/controllers/notebooks.controller.ts
@@ -220,6 +220,32 @@ export function useImportAllNotebooks() {
   });
 }
 
+// Import all notebooks from a bulk export, given an already-selected file
+// path (used when the caller needs to inspect the file, e.g. for embedded
+// connection details, before committing to the import).
+export function useImportAllNotebooksFromPath() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      connectionId,
+      filePath,
+    }: {
+      connectionId: string;
+      filePath: string;
+    }) => notebooksService.importAllNotebooks(connectionId, filePath),
+    onSuccess: (notebooks, { connectionId }) => {
+      queryClient.invalidateQueries(notebooksKeys.list(connectionId));
+      toast.success(
+        `Successfully imported ${notebooks.length} notebook${notebooks.length > 1 ? 's' : ''}`,
+      );
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to import notebooks: ${error.message}`);
+    },
+  });
+}
+
 // Delete a notebook
 export function useDeleteNotebook() {
   const queryClient = useQueryClient();

--- a/src/renderer/screens/notebooks/index.tsx
+++ b/src/renderer/screens/notebooks/index.tsx
@@ -32,13 +32,18 @@ import {
   Link as LinkIcon,
   Warning,
   InsertChart,
+  Upload,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   ChatBubbleOutline,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { AppLayout } from '../../layouts';
-import { useGetConnections, useDuckLakeInstances } from '../../controllers';
+import {
+  useGetConnections,
+  useDuckLakeInstances,
+  useImportConnectionFromNotebook,
+} from '../../controllers';
 import {
   useArchivedNotebooks,
   useRestoreNotebook,
@@ -47,7 +52,7 @@ import {
   useCreateNotebook,
   useNotebooks,
   useDeleteNotebook,
-  useImportAllNotebooks,
+  useImportAllNotebooksFromPath,
   useRenameNotebook,
   useDuplicateNotebook,
 } from '../../controllers/notebooks.controller';
@@ -56,13 +61,23 @@ import connectionIcons, {
 } from '../../../../assets/connectionIcons';
 import { AppContext } from '../../context';
 import { connectorsServices, DuckLakeService } from '../../services';
+import { notebooksService } from '../../services/notebooks.service';
 import { AnalyticsEditor } from '../../components/analytics';
 import { NotebooksSidebar } from '../../components/notebook/NotebooksSidebar';
 import { NotebookTabManager } from '../../components/notebook/NotebookTabManager';
 import { NotebookEditor } from '../../components/notebook';
+import { ExportNotebookDialog } from '../../components/notebook/ExportNotebookDialog';
+import { ImportConnectionDialog } from '../../components/notebook/ImportConnectionDialog';
 import { ChatWindow } from '../../components/chat';
-import { Table, SupportedConnectionTypes } from '../../../types/backend';
+import {
+  Table,
+  SupportedConnectionTypes,
+  ConnectionInput,
+} from '../../../types/backend';
+import { NotebookImportPreview } from '../../../types/notebooks';
 import useNotebookTabManager from '../../hooks/useNotebookTabManager';
+import useSecureStorage from '../../hooks/useSecureStorage';
+import { resolveConnectionCredentials } from '../../utils/notebookConnectionTransfer';
 import {
   useNotebookConnectionState,
   useNotebookSidebarState,
@@ -196,9 +211,11 @@ const Notebooks = () => {
   const { data: notebooks = [], isLoading: isLoadingNotebooks } =
     useNotebooks(activeConnectionId);
   const deleteNotebook = useDeleteNotebook();
-  const importAllNotebooks = useImportAllNotebooks();
+  const importAllNotebooksFromPath = useImportAllNotebooksFromPath();
+  const importConnectionFromNotebook = useImportConnectionFromNotebook();
   const renameNotebook = useRenameNotebook();
   const duplicateNotebook = useDuplicateNotebook();
+  const secureStorage = useSecureStorage();
 
   // Archived notebooks state
   const { data: archivedNotebooks = {} } = useArchivedNotebooks();
@@ -215,6 +232,13 @@ const Notebooks = () => {
     useState(false);
   const [renameNotebookOpen, setRenameNotebookOpen] = useState(false);
   const [duplicateNotebookOpen, setDuplicateNotebookOpen] = useState(false);
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
+  const [importConnectionDialogOpen, setImportConnectionDialogOpen] =
+    useState(false);
+  const [pendingImport, setPendingImport] = useState<{
+    filePath: string;
+    preview: NotebookImportPreview;
+  } | null>(null);
   const [newNotebookName, setNewNotebookName] = useState('');
   const [newNotebookDescription, setNewNotebookDescription] = useState('');
   const [renameNotebookId, setRenameNotebookId] = useState<string | null>(null);
@@ -488,23 +512,104 @@ const Notebooks = () => {
     notebookTabManager,
   ]);
 
+  // Import notebooks (and optionally the connection they were exported from)
+  // into the given connection, opening the first imported notebook.
+  const runNotebookImport = useCallback(
+    async (filePath: string, connectionId: string) => {
+      try {
+        const imported = await importAllNotebooksFromPath.mutateAsync({
+          connectionId,
+          filePath,
+        });
+
+        if (imported.length > 0) {
+          if (connectionId !== activeConnectionId) {
+            setActiveConnectionId(connectionId);
+          }
+          notebookTabManager.openNotebook(imported[0], connectionId);
+        }
+      } catch (err) {
+        // Error handled by mutation
+      }
+    },
+    [
+      importAllNotebooksFromPath,
+      activeConnectionId,
+      setActiveConnectionId,
+      notebookTabManager,
+    ],
+  );
+
   // Handle import all notebooks
   const handleImportAllNotebooks = useCallback(async () => {
-    if (!activeConnectionId) return;
-
+    let filePath: string | null;
     try {
-      const imported = await importAllNotebooks.mutateAsync({
-        connectionId: activeConnectionId,
-      });
-
-      // Open the first imported notebook in a new tab
-      if (imported.length > 0) {
-        notebookTabManager.openNotebook(imported[0], activeConnectionId);
-      }
+      filePath = await notebooksService.selectImportFile();
     } catch (err) {
-      // Error handled by mutation
+      toast.error(`Failed to select import file: ${(err as Error).message}`);
+      return;
     }
-  }, [activeConnectionId, importAllNotebooks, notebookTabManager]);
+    if (!filePath) return;
+
+    let preview: NotebookImportPreview;
+    try {
+      preview = await notebooksService.peekImportFile(filePath);
+    } catch (err) {
+      toast.error((err as Error).message);
+      return;
+    }
+
+    if (preview.connection) {
+      setPendingImport({ filePath, preview });
+      setImportConnectionDialogOpen(true);
+      return;
+    }
+
+    if (!activeConnectionId) {
+      toast.error(
+        'This file has no connection details. Add or select a connection first, then import.',
+      );
+      return;
+    }
+
+    await runNotebookImport(filePath, activeConnectionId);
+  }, [activeConnectionId, runNotebookImport]);
+
+  // Handle confirming the import-connection dialog
+  const handleImportConnectionConfirm = useCallback(
+    async (shouldImportConnection: boolean) => {
+      if (!pendingImport) return;
+      const { filePath, preview } = pendingImport;
+      setImportConnectionDialogOpen(false);
+      setPendingImport(null);
+
+      let targetConnectionId = activeConnectionId;
+      if (shouldImportConnection && preview.connection) {
+        try {
+          const { id } = await importConnectionFromNotebook.mutateAsync(
+            preview.connection,
+          );
+          targetConnectionId = id;
+        } catch (err) {
+          toast.error(`Failed to import connection: ${(err as Error).message}`);
+          return;
+        }
+      }
+
+      if (!targetConnectionId) {
+        toast.error('No connection available to import notebooks into.');
+        return;
+      }
+
+      await runNotebookImport(filePath, targetConnectionId);
+    },
+    [
+      pendingImport,
+      activeConnectionId,
+      importConnectionFromNotebook,
+      runNotebookImport,
+    ],
+  );
 
   // Handle open notebook (placeholder - will navigate to notebook editor)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -632,53 +737,83 @@ const Notebooks = () => {
     notebookTabManager,
   ]);
 
-  const handleExportAllNotebooks = useCallback(() => {
+  const handleExportAllNotebooksClick = useCallback(() => {
     if (notebooks.length === 0) {
       return;
     }
-    const exportData = {
-      exportDate: new Date().toISOString(),
-      connectionId: activeConnectionId,
-      connectionName: activeConnection?.connection.name,
-      notebooks: notebooks.map((notebook) => ({
-        id: notebook.id,
-        name: notebook.name,
-        description: notebook.description,
-        cells: notebook.cells.map((cell) => ({
-          id: cell.id,
-          type: cell.type,
-          content: cell.content,
-          order: cell.order,
-          // Exclude output data to keep file size small
-          output: cell.output
-            ? {
-                type: cell.output.type,
-                columns: cell.output.columns,
-                rowCount: cell.output.rowCount,
-                totalRows: cell.output.totalRows,
-                executionTime: cell.output.executionTime,
-                // Explicitly exclude data array
-              }
-            : undefined,
-        })),
-        createdAt: notebook.createdAt,
-        updatedAt: notebook.updatedAt,
-      })),
-    };
+    setExportDialogOpen(true);
+  }, [notebooks.length]);
 
-    // Download as JSON file
-    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
-      type: 'application/json',
-    });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `notebooks-${activeConnection?.connection.name || 'export'}-${new Date().toISOString().split('T')[0]}.json`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  }, [notebooks, activeConnectionId, activeConnection]);
+  const isDuckLakeActiveConnection = activeConnectionId.startsWith('ducklake-');
+
+  const handleExportAllNotebooksConfirm = useCallback(
+    async (includeConnection: boolean) => {
+      setExportDialogOpen(false);
+
+      let connectionDetails: ConnectionInput | undefined;
+      if (
+        includeConnection &&
+        activeConnection &&
+        !isDuckLakeActiveConnection
+      ) {
+        connectionDetails = await resolveConnectionCredentials(
+          activeConnection.connection as ConnectionInput,
+          secureStorage,
+        );
+      }
+
+      const exportData = {
+        exportDate: new Date().toISOString(),
+        connectionId: activeConnectionId,
+        connectionName: activeConnection?.connection.name,
+        connection: connectionDetails,
+        notebooks: notebooks.map((notebook) => ({
+          id: notebook.id,
+          name: notebook.name,
+          description: notebook.description,
+          cells: notebook.cells.map((cell) => ({
+            id: cell.id,
+            type: cell.type,
+            content: cell.content,
+            order: cell.order,
+            // Exclude output data to keep file size small
+            output: cell.output
+              ? {
+                  type: cell.output.type,
+                  columns: cell.output.columns,
+                  rowCount: cell.output.rowCount,
+                  totalRows: cell.output.totalRows,
+                  executionTime: cell.output.executionTime,
+                  // Explicitly exclude data array
+                }
+              : undefined,
+          })),
+          createdAt: notebook.createdAt,
+          updatedAt: notebook.updatedAt,
+        })),
+      };
+
+      // Download as JSON file
+      const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `notebooks-${activeConnection?.connection.name || 'export'}-${new Date().toISOString().split('T')[0]}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    },
+    [
+      notebooks,
+      activeConnectionId,
+      activeConnection,
+      isDuckLakeActiveConnection,
+      secureStorage,
+    ],
+  );
 
   // Show loading state while hydrating
   if (!isFullyHydrated) {
@@ -1026,7 +1161,7 @@ const Notebooks = () => {
               }}
               onToggleArchived={setShowArchived}
               getConnectionName={getConnectionName}
-              onExportAllNotebooks={handleExportAllNotebooks}
+              onExportAllNotebooks={handleExportAllNotebooksClick}
               onImportAllNotebooks={handleImportAllNotebooks}
               onTabChange={setActiveSidebarTab}
               connectionId={activeConnectionId}
@@ -1097,6 +1232,7 @@ const Notebooks = () => {
                       variant="body2"
                       color="text.secondary"
                       sx={{
+                        mb: 2,
                         textAlign: 'center',
                         wordWrap: 'break-word',
                         overflowWrap: 'break-word',
@@ -1106,6 +1242,20 @@ const Notebooks = () => {
                       Select a connection from the sidebar to start working with
                       notebooks
                     </Typography>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ mb: 1 }}
+                    >
+                      or
+                    </Typography>
+                    <Button
+                      variant="outlined"
+                      startIcon={<Upload />}
+                      onClick={handleImportAllNotebooks}
+                    >
+                      Import Notebook (JSON)
+                    </Button>
                   </Box>
                 );
               }
@@ -1572,6 +1722,32 @@ const Notebooks = () => {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* Export All Notebooks Dialog */}
+      <ExportNotebookDialog
+        open={exportDialogOpen}
+        onClose={() => setExportDialogOpen(false)}
+        onConfirm={handleExportAllNotebooksConfirm}
+        subject={`${notebooks.length} notebook${notebooks.length > 1 ? 's' : ''}`}
+        connectionName={activeConnection?.connection.name}
+        connectionExportDisabled={
+          isDuckLakeActiveConnection || !activeConnection
+        }
+      />
+
+      {/* Import Connection Dialog */}
+      <ImportConnectionDialog
+        open={importConnectionDialogOpen}
+        connectionName={pendingImport?.preview.connectionName}
+        connectionType={pendingImport?.preview.connection?.type}
+        notebookCount={pendingImport?.preview.notebookCount ?? 1}
+        hasActiveConnection={!!activeConnectionId}
+        onClose={() => {
+          setImportConnectionDialogOpen(false);
+          setPendingImport(null);
+        }}
+        onConfirm={handleImportConnectionConfirm}
+      />
     </AppLayout>
   );
 };

--- a/src/renderer/screens/notebooks/index.tsx
+++ b/src/renderer/screens/notebooks/index.tsx
@@ -762,12 +762,18 @@ const Notebooks = () => {
         );
       }
 
+      // Fetch fresh from disk instead of the notebooks list cache, which is
+      // never invalidated when cells are added/edited (only on
+      // create/rename/delete), and can be stale by the time of export.
+      const freshNotebooks =
+        await notebooksService.listNotebooks(activeConnectionId);
+
       const exportData = {
         exportDate: new Date().toISOString(),
         connectionId: activeConnectionId,
         connectionName: activeConnection?.connection.name,
         connection: connectionDetails,
-        notebooks: notebooks.map((notebook) => ({
+        notebooks: freshNotebooks.map((notebook) => ({
           id: notebook.id,
           name: notebook.name,
           description: notebook.description,
@@ -807,7 +813,6 @@ const Notebooks = () => {
       URL.revokeObjectURL(url);
     },
     [
-      notebooks,
       activeConnectionId,
       activeConnection,
       isDuckLakeActiveConnection,

--- a/src/renderer/screens/notebooks/index.tsx
+++ b/src/renderer/screens/notebooks/index.tsx
@@ -65,7 +65,10 @@ import { notebooksService } from '../../services/notebooks.service';
 import { AnalyticsEditor } from '../../components/analytics';
 import { NotebooksSidebar } from '../../components/notebook/NotebooksSidebar';
 import { NotebookTabManager } from '../../components/notebook/NotebookTabManager';
-import { NotebookEditor } from '../../components/notebook';
+import {
+  NotebookEditor,
+  flushNotebookPendingSave,
+} from '../../components/notebook';
 import { ExportNotebookDialog } from '../../components/notebook/ExportNotebookDialog';
 import { ImportConnectionDialog } from '../../components/notebook/ImportConnectionDialog';
 import { ChatWindow } from '../../components/chat';
@@ -760,6 +763,9 @@ const Notebooks = () => {
           activeConnection.connection as ConnectionInput,
           secureStorage,
         );
+      }
+      if (notebookTabManager.activeTabId) {
+        await flushNotebookPendingSave(notebookTabManager.activeTabId);
       }
 
       // Fetch fresh from disk instead of the notebooks list cache, which is

--- a/src/renderer/services/notebooks.service.ts
+++ b/src/renderer/services/notebooks.service.ts
@@ -3,7 +3,12 @@
  * Frontend service for notebook operations
  */
 
-import { Notebook, NotebookCell, CellOutput } from '../../types/notebooks';
+import {
+  Notebook,
+  NotebookCell,
+  CellOutput,
+  NotebookImportPreview,
+} from '../../types/notebooks';
 
 export const notebooksService = {
   /**
@@ -100,6 +105,17 @@ export const notebooksService = {
    */
   selectImportFile: async (): Promise<string | null> => {
     return window.electron.ipcRenderer.invoke('notebooks:selectImportFile');
+  },
+
+  /**
+   * Peek at a notebook export JSON file (check for embedded connection
+   * details) without importing it
+   */
+  peekImportFile: async (filePath: string): Promise<NotebookImportPreview> => {
+    return window.electron.ipcRenderer.invoke(
+      'notebooks:peekImportFile',
+      filePath,
+    );
   },
 
   /**

--- a/src/renderer/utils/notebookConnectionTransfer.ts
+++ b/src/renderer/utils/notebookConnectionTransfer.ts
@@ -1,0 +1,95 @@
+/**
+ * Helpers for carrying full connection details (including credentials)
+ * inside notebook export/import JSON files.
+ */
+import { ConnectionInput, ConnectionModel } from '../../types/backend';
+import useSecureStorage from '../hooks/useSecureStorage';
+
+type SecureStorage = ReturnType<typeof useSecureStorage>;
+
+/**
+ * Overlay the real credentials from secure storage onto a connection object,
+ * mirroring how the main process resolves credentials at query time
+ * (ConnectorsService.executeSelectStatement). The connection object stored
+ * in the app DB does not reliably hold the live secret (e.g. BigQuery
+ * keyfiles are replaced with a placeholder on write), so secure storage is
+ * the source of truth.
+ */
+export async function resolveConnectionCredentials(
+  connection: ConnectionInput,
+  secureStorage: SecureStorage,
+): Promise<ConnectionInput> {
+  const resolved: any = { ...connection };
+  const { name } = connection;
+
+  if ('username' in resolved) {
+    const storedUsername = await secureStorage.getDatabaseUsername(name);
+    if (storedUsername) resolved.username = storedUsername;
+  }
+  if ('password' in resolved) {
+    const storedPassword = await secureStorage.getDatabasePassword(name);
+    if (storedPassword) resolved.password = storedPassword;
+  }
+  if ('token' in resolved) {
+    const storedToken = await secureStorage.getDatabaseToken(name);
+    if (storedToken) resolved.token = storedToken;
+  }
+  if (resolved.type === 'bigquery') {
+    const storedKey = await secureStorage.getBigQueryServiceAccountKey(name);
+    if (storedKey) resolved.keyfile = storedKey;
+  }
+
+  return resolved as ConnectionInput;
+}
+
+/**
+ * Persist the credentials embedded in an imported connection into secure
+ * storage, matching the writes each connection form performs on save
+ * (see e.g. components/connections/postgres.tsx handleSubmit).
+ */
+export async function storeImportedConnectionCredentials(
+  connection: ConnectionInput,
+  secureStorage: SecureStorage,
+): Promise<void> {
+  const { name } = connection;
+  const asAny = connection as any;
+
+  if ('username' in connection && asAny.username) {
+    await secureStorage.setDatabaseUsername(asAny.username, name);
+  }
+  if ('password' in connection && asAny.password) {
+    await secureStorage.setDatabasePassword(asAny.password, name);
+  }
+  if ('token' in connection && asAny.token) {
+    await secureStorage.setDatabaseToken(asAny.token, name);
+  }
+  if (connection.type === 'bigquery' && asAny.keyfile) {
+    await secureStorage.setBigQueryServiceAccountKey(asAny.keyfile, name);
+  }
+}
+
+/**
+ * Given a desired connection name, return a name that doesn't collide
+ * (case-insensitively) with any existing connection, appending
+ * "(Imported)" / "(Imported N)" as needed.
+ */
+export function getUniqueConnectionName(
+  name: string,
+  existingConnections: ConnectionModel[],
+): string {
+  const taken = new Set(
+    existingConnections.map((c) => c.connection.name.trim().toLowerCase()),
+  );
+
+  if (!taken.has(name.trim().toLowerCase())) {
+    return name;
+  }
+
+  let candidate = `${name} (Imported)`;
+  let counter = 2;
+  while (taken.has(candidate.trim().toLowerCase())) {
+    candidate = `${name} (Imported ${counter})`;
+    counter += 1;
+  }
+  return candidate;
+}

--- a/src/renderer/utils/notebookConnectionTransfer.ts
+++ b/src/renderer/utils/notebookConnectionTransfer.ts
@@ -68,6 +68,27 @@ export async function storeImportedConnectionCredentials(
   }
 }
 
+export async function deleteImportedConnectionCredentials(
+  connection: ConnectionInput,
+  secureStorage: SecureStorage,
+): Promise<void> {
+  const { name } = connection;
+  const asAny = connection as any;
+
+  if ('username' in connection && asAny.username) {
+    await secureStorage.deleteDatabaseUsername(name);
+  }
+  if ('password' in connection && asAny.password) {
+    await secureStorage.deleteDatabasePassword(name);
+  }
+  if ('token' in connection && asAny.token) {
+    await secureStorage.deleteDatabaseToken(name);
+  }
+  if (connection.type === 'bigquery' && asAny.keyfile) {
+    await secureStorage.deleteBigQueryServiceAccountKey(name);
+  }
+}
+
 /**
  * Given a desired connection name, return a name that doesn't collide
  * (case-insensitively) with any existing connection, appending

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -394,6 +394,7 @@ export type NotebookChannels =
   | 'notebooks:rename'
   | 'notebooks:duplicate'
   | 'notebooks:selectImportFile'
+  | 'notebooks:peekImportFile'
   | 'notebooks:import'
   | 'notebooks:importAll'
   | 'notebooks:delete'

--- a/src/types/notebooks.ts
+++ b/src/types/notebooks.ts
@@ -3,6 +3,8 @@
  * Type definitions for notebook functionality
  */
 
+import { ConnectionInput } from './backend';
+
 export interface CellOutput {
   type: 'table' | 'error' | 'empty';
   data?: any[];
@@ -32,6 +34,15 @@ export interface Notebook {
   updatedAt: string;
   lastExecutedAt?: string;
   cellCount: number;
+}
+
+/** Preview of a notebook JSON export file, returned before the file is actually imported. */
+export interface NotebookImportPreview {
+  isBulk: boolean;
+  notebookCount: number;
+  /** Present only if the export included full connection details (see "Include connection details" export option). */
+  connection?: ConnectionInput;
+  connectionName?: string;
 }
 
 export interface CompletionItem {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Export notebooks as JSON with optional connection details and credentials.
  - Import notebooks from JSON files, including a preview and optional connection import.
  - Automatically avoid duplicate names when importing connections.
  - Import notebooks from the no-connection state.

- **Bug Fixes**
  - Prevented concurrent notebook updates from overwriting each other.
  - Exports now use the latest notebook data instead of potentially stale information.
  - Notebook cell output remains excluded from exported files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->