### PR TITLE
feat: update selected file state on pipeline tab opening and remove r…

### DIFF
--- a/src/renderer/components/settings/RosettaSettings.tsx
+++ b/src/renderer/components/settings/RosettaSettings.tsx
@@ -86,7 +86,6 @@ export const RosettaSettings: React.FC<RosettaSettingsProps> = ({
   const checkVersions = useCheckRosettaVersions({
     onSuccess: (data) => {
       setVersionInfo(data);
-      toast.success('Version information updated');
     },
     onError: (error) => {
       toast.error(`Failed to check versions: ${error.message}`);

--- a/src/renderer/screens/projectDetails/index.tsx
+++ b/src/renderer/screens/projectDetails/index.tsx
@@ -868,6 +868,7 @@ const ProjectDetails: React.FC = () => {
       if (isPipelineFile(filePath)) {
         const pipelineTabPath = toPipelineTabPath(filePath);
         const alreadyOpen = !!getTabByPath(pipelineTabPath);
+        setSelectedFilePath(filePath);
         openTab(pipelineTabPath, {
           title: deriveTitleFromPath(filePath),
           content: '',


### PR DESCRIPTION
…edundant version check success toast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Opening a pipeline file now correctly updates the selected file path.
  - Opening pipeline files now displays the corresponding pipeline tab with the correct selection state.

- **User Experience**
  - Removed the success notification shown after Rosetta version information is retrieved; version details continue to update as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->