### PR TITLE
fix: improve project import error messages

### DIFF
--- a/src/main/services/projects.service.ts
+++ b/src/main/services/projects.service.ts
@@ -525,7 +525,7 @@ export default class ProjectsService {
       const dbtRoot = await this.findDbtProjectRoot(projectPath);
       if (!dbtRoot) {
         throw new Error(
-          'No dbt_project.yml found. Please ensure this is a valid dbt project.',
+          `"${path.basename(selectedPath)}" does not contain a dbt_project.yml file. Please select a valid dbt project folder.`,
         );
       }
       projectPath = dbtRoot;

--- a/src/renderer/screens/selectProject/index.tsx
+++ b/src/renderer/screens/selectProject/index.tsx
@@ -715,20 +715,15 @@ const SelectProject: React.FC = () => {
                           return;
                         }
 
-                        // Show more specific error messages
                         if (error.message.includes('compressed')) {
                           toast.error(
                             'Failed to extract compressed file. Please ensure it contains a valid dbt project.',
                           );
-                        } else if (error.message.includes('validation')) {
-                          toast.error(
-                            'Invalid dbt project structure. Please ensure the folder contains a valid dbt_project.yml file.',
-                          );
-                        } else if (error.message.includes('already exists')) {
-                          toast.error(error.message);
                         } else {
                           toast.error(
-                            'Failed to import project. Please try again.',
+                            error instanceof Error
+                              ? error.message
+                              : 'Failed to import project. Please try again.',
                           );
                         }
                       }


### PR DESCRIPTION
Include the selected folder name in the "no dbt_project.yml" error so users know exactly which folder failed validation. Surface service error messages directly in the toast instead of re-mapping through fragile string matching, so "already imported" and other specific errors are shown verbatim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project import errors by identifying the selected file or folder when `dbt_project.yml` is missing.
  * Updated import error handling to display specific error messages when available, with a generic fallback when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->